### PR TITLE
fix: persist events across save/load + German translation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -47,7 +47,7 @@ body:
     attributes:
       label: What happened?
       description: Describe the bug clearly. What did you see? What did you expect to see?
-      placeholder: "A drought event triggered but crop stress never changed, even after several in-game days."
+      placeholder: "A hailstorm event fired but the notification appeared instantly with no warning. The event also lasted 0 seconds — crops were marked damaged but weather never changed visually."
     validations:
       required: true
 
@@ -55,12 +55,12 @@ body:
     id: steps
     attributes:
       label: Steps to Reproduce
-      description: Exact steps that trigger the bug. If you cannot reproduce it reliably, say so.
+      description: Exact steps that trigger the bug. Note the event type and in-game day if known.
       placeholder: |
-        1. Start a new game on Elmcreek
-        2. Wait for a drought event to trigger
-        3. Check field conditions after 3 in-game days
-        4. No change in crop stress visible
+        1. Start a new game on Elmcreek with RWE active
+        2. Wait until day 12
+        3. A hailstorm event fires
+        4. Notification pops immediately, crops show damage, but weather does not change
     validations:
       required: true
 
@@ -73,8 +73,9 @@ body:
         If there are errors (lines containing "Error" or "attempt to"), include the full stack trace.
       render: text
       placeholder: |
-        [RWE] RandomWorldEvents initialized
-        [RWE] Event triggered: drought (severity=high)
+        [RWE] Initialized. Events loaded: 12
+        [RWE] Event scheduled: HAILSTORM, day=12, severity=HIGH
+        [RWE] Event fired: HAILSTORM, duration=0s
         ...
     validations:
       required: true
@@ -83,8 +84,8 @@ body:
     id: other_mods
     attributes:
       label: Other Mods Loaded
-      description: List any other mods active in this save.
-      placeholder: "FS25_SeasonalCropStress, Courseplay, AutoDrive, ..."
+      description: List any other mods active in this save. You can paste the mod list from the game's mod manager.
+      placeholder: "FS25_SeasonalCropStress, FS25_SoilFertilizer, Courseplay, ..."
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/compatibility_report.yml
+++ b/.github/ISSUE_TEMPLATE/compatibility_report.yml
@@ -12,7 +12,7 @@ body:
   - type: input
     id: mod_version
     attributes:
-      label: RandomWorldEvents Version
+      label: Random World Events Version
       placeholder: "e.g. 1.0.0.0"
     validations:
       required: true
@@ -46,6 +46,7 @@ body:
     id: other_mod_source
     attributes:
       label: Where did you get the conflicting mod?
+      description: ModHub, GitHub link, or other source. Helps us check the exact version.
       placeholder: "https://github.com/..."
     validations:
       required: true
@@ -54,8 +55,8 @@ body:
     id: description
     attributes:
       label: What is the conflict?
-      description: Describe exactly what goes wrong.
-      placeholder: "When FS25_SeasonalCropStress is loaded, random events stop triggering entirely after a drought event fires."
+      description: Describe exactly what goes wrong. Events not triggering? Double effects? Another mod's systems broken by events? Be specific.
+      placeholder: "When FS25_SeasonalCropStress is loaded, a drought event from RWE stacks with SeasonalCropStress drought effects, pushing stress values far beyond the normal maximum."
     validations:
       required: true
 
@@ -63,6 +64,12 @@ body:
     id: steps
     attributes:
       label: Steps to Reproduce
+      description: How to trigger the conflict reliably.
+      placeholder: |
+        1. Load both mods
+        2. Start a new game in summer
+        3. Wait for RWE to fire a drought event
+        4. Crop stress immediately jumps to 200% (beyond the 100% max)
     validations:
       required: true
 
@@ -70,8 +77,8 @@ body:
     id: isolation
     attributes:
       label: Isolation Test
-      description: Did you confirm the issue disappears when the conflicting mod is removed?
-      placeholder: "Yes — removing FS25_SeasonalCropStress makes events trigger normally again."
+      description: Did you confirm the issue disappears when the conflicting mod is removed? This is important — without this step we cannot tell which mod is the source.
+      placeholder: "Yes — removing FS25_SeasonalCropStress makes drought events apply normal stress values."
     validations:
       required: true
 
@@ -79,7 +86,7 @@ body:
     id: log
     attributes:
       label: Log Snippet
-      description: Paste all `[RWE]` lines from your log.txt, plus any errors in the same session.
+      description: Paste all `[RWE]` lines from your log.txt, plus any errors in the same session. Include the full stack trace if there is one.
       render: text
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,14 +8,14 @@ body:
         **Before opening this request:**
         - Check the roadmap in the README — your idea may already be planned.
         - Check open issues to avoid duplicates.
-        - Keep requests scoped and specific. "More events" will be closed. "Add a hailstorm event that damages crops in a radius around the impact zone" is actionable.
+        - Keep requests scoped and specific. "More events" will be closed. "Add a locust swarm event that reduces crop yield on affected fields by 30-70% over 3 in-game days" is actionable.
 
   - type: textarea
     id: problem
     attributes:
       label: What problem does this solve?
       description: Describe the situation or frustration this would address. Focus on the problem, not the solution.
-      placeholder: "I never know when an event is about to fire, so I can't prepare in time."
+      placeholder: "High-intensity events currently fire with no warning, leaving no time to react. There is no way to distinguish a coming minor event from a catastrophic one until it is already happening."
     validations:
       required: true
 
@@ -23,8 +23,8 @@ body:
     id: proposal
     attributes:
       label: Proposed Solution
-      description: Describe what you want to happen. Be specific.
-      placeholder: "Add a warning notification 1 in-game hour before an event triggers, so the player has time to react."
+      description: Describe what you want to happen. Be specific about the behavior, not just the concept.
+      placeholder: "Add a configurable advance warning window (e.g. 1-6 in-game hours) that shows a forecast notification for upcoming events. The warning text should hint at the event type and intensity without completely spoiling it."
     validations:
       required: true
 
@@ -32,6 +32,7 @@ body:
     id: alternatives
     attributes:
       label: Alternatives Considered
+      description: Have you thought of other ways to solve this? Why are they not good enough?
     validations:
       required: false
 
@@ -40,12 +41,11 @@ body:
     attributes:
       label: Which part of the mod does this relate to?
       options:
-        - Event System & Triggers
-        - Event Types & Effects
-        - Notifications & UI
-        - Settings / Difficulty
-        - Multiplayer
+        - Event Types
+        - Event Frequency / Intensity
+        - HUD / Notifications
         - Mod Compatibility
+        - Settings
         - Other
     validations:
       required: true
@@ -54,5 +54,6 @@ body:
     id: additional
     attributes:
       label: Anything Else?
+      description: Screenshots, mockups, references to how other mods handle this, or any extra context.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/other.yml
+++ b/.github/ISSUE_TEMPLATE/other.yml
@@ -1,0 +1,22 @@
+name: Other
+description: Something that doesn't fit the other templates.
+labels: ["needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for questions, general feedback, or anything that doesn't fit Bug Report, Compatibility Report, or Feature Request.
+        For questions only, consider [Discussions](https://github.com/TheCodingDad-TisonK/FS25_RandomWorldEvents/discussions) instead.
+  - type: textarea
+    id: description
+    attributes:
+      label: What's on your mind?
+      description: Be as specific as possible.
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: Anything Else?
+    validations:
+      required: false

--- a/.github/workflows/issue-timeout.yml
+++ b/.github/workflows/issue-timeout.yml
@@ -40,7 +40,6 @@ jobs:
                 per_page: 100
               });
 
-              // Find when owner last replied
               const ownerAssociations = ['OWNER', 'MEMBER', 'COLLABORATOR'];
               const ownerComments = comments.data.filter(c =>
                 ownerAssociations.includes(c.author_association) && c.user.type !== 'Bot'
@@ -51,7 +50,6 @@ jobs:
               const age = now - lastOwnerReply;
               if (age < twentyFourHours) continue;
 
-              // Check if user replied after the owner's last comment
               const author = issue.user.login;
               const userRepliedAfter = comments.data.some(c =>
                 c.user.login === author &&
@@ -60,16 +58,17 @@ jobs:
               if (userRepliedAfter) continue;
 
               const closeBody = [
-                `Hey @${author} — this issue has been automatically closed because there was no follow-up within **24 hours** of the last response.`,
+                `Hey @${author} — the storm has passed on this one. This issue is being closed automatically because there was no follow-up within **24 hours** of the last response.`,
                 ``,
-                `This is not a rejection. If you still have the problem, please **reopen this issue** and include:`,
+                `This is not a rejection! If you still have the problem, please **reopen this issue** and include:`,
                 ``,
-                `- The relevant lines from your \`log.txt\``,
+                `- The relevant \`[RWE]\` lines from your \`log.txt\``,
                 `  - Location: \`Documents/My Games/FarmingSimulator2025/log.txt\``,
                 `- Your mod version (visible in the mod manager)`,
+                `- Which event type is affected, its intensity, and what in-game day it occurred on`,
                 `- Steps to reproduce the issue`,
                 ``,
-                `We look forward to helping you once we have the details!`,
+                `Another event is always around the corner — we look forward to your return!`,
               ].join('\n');
 
               await github.rest.issues.createComment({

--- a/.github/workflows/issue-welcome.yml
+++ b/.github/workflows/issue-welcome.yml
@@ -28,22 +28,22 @@ jobs:
           script: |
             const author = context.payload.issue.user.login;
             const repoName = context.repo.repo;
-            const modName = repoName.replace('FS25_', '').replace(/([A-Z])/g, ' $1').trim();
 
             const body = [
-              `Hey @${author}, thanks for opening this issue! 👋`,
+              `Hey @${author}, an unexpected event has arrived — your issue report! ⚡`,
               ``,
-              `@TheCodingDad-TisonK has been notified and will take a look as soon as possible.`,
+              `@TheCodingDad-TisonK has been notified and will investigate as soon as possible.`,
               ``,
-              `**While you wait, please double-check the following:**`,
+              `**To help reproduce the chaos, please confirm:**`,
               ``,
-              `- [ ] You are running the latest version of ${modName} (visible in the mod manager)`,
-              `- [ ] Your issue includes relevant lines from \`log.txt\``,
+              `- [ ] You are running the latest version of Random World Events (visible in the mod manager)`,
+              `- [ ] Your issue includes the relevant \`[RWE]\` lines from \`log.txt\``,
               `  - Log location: \`Documents/My Games/FarmingSimulator2025/log.txt\``,
-              `  - Search for \`[${modName}]\` — paste the relevant section in your issue`,
+              `  - Search for \`[RWE]\` and paste the relevant section here`,
+              `- [ ] If this involves a specific event — note the event type, intensity level, and what in-game day it occurred on`,
               `- [ ] You have searched [existing issues](https://github.com/${context.repo.owner}/${repoName}/issues) for a similar report`,
               ``,
-              `> **Important:** If this issue is missing a log snippet, it may be closed without investigation. A log is almost always required to reproduce bugs.`,
+              `> **Note:** Issues without a log snippet are difficult to investigate and may be closed. Event trigger bugs especially need log data to trace the sequence.`,
             ].join('\n');
 
             await github.rest.issues.createComment({

--- a/.github/workflows/traffic-stats.yml
+++ b/.github/workflows/traffic-stats.yml
@@ -1,0 +1,935 @@
+# ============================================================================
+# GitHub Repository Traffic Stats — Reusable Template
+# ============================================================================
+#
+# WHAT THIS IS:
+#   A copy-paste-ready GitHub Actions workflow that archives your repository's
+#   traffic data (views, clones, downloads, referrers, stars, forks) beyond
+#   GitHub's default 14-day retention window, and generates a visual dashboard
+#   with charts.
+#
+# HOW TO USE:
+#   1. Copy this file to: .github/workflows/traffic-stats.yml
+#   2. Create a Personal Access Token (classic) with `repo` scope
+#   3. Add it as a repository secret named TRAFFIC_TOKEN
+#   4. Push to your default branch — the workflow runs hourly on schedule
+#   5. After the first run, check the `traffic-stats` branch for your dashboard
+#      at .github/traffic/SUMMARY.md
+#
+# WHAT IT COLLECTS:
+#   - Hourly:  Release download counts (lightweight snapshot)
+#   - Every 6h: Full dashboard — views, clones, referrers, stars, forks,
+#               watchers, popular paths + chart generation
+#   - Manual:  Trigger anytime via workflow_dispatch for a full collection
+#
+# DATA STORAGE:
+#   All data is committed to an orphan branch called `traffic-stats` so it
+#   never clutters your main branch. Data files:
+#     - daily.json       — Views & clones per day (preserved forever)
+#     - downloads.json   — Release download snapshots (hourly)
+#     - referrers.json   — Referrer snapshots (daily)
+#     - metadata.json    — Stars, forks, watchers (daily)
+#     - stats.json       — Combined legacy snapshots (6-hourly)
+#     - charts/*.png     — Auto-generated dashboard charts
+#     - SUMMARY.md       — Markdown dashboard with embedded charts
+#
+# SMART DEDUPLICATION:
+#   Download snapshots are only recorded when the count changes, with a
+#   heartbeat entry every 6 hours to keep the timeline alive. Daily data
+#   uses date-keyed upserts so re-runs don't create duplicates.
+#
+# REQUIREMENTS:
+#   - Repository secret: TRAFFIC_TOKEN (PAT with `repo` scope)
+#   - The PAT owner must have push access to the repository
+#
+# CHARTS GENERATED (6 total):
+#   1. Views & Clones — dual-panel time series
+#   2. Total Acquisition per Release — stacked bars + daily clone timeline
+#   3. Referrers — horizontal bar chart
+#   4. Repository Growth — stars, forks, watchers line chart
+#   5. Visitor Engagement — pages per visitor with trend line
+#   6. Conversion Funnel — visitors vs downloaders with conversion rate
+#
+# ============================================================================
+
+name: Traffic Stats Archive
+
+on:
+  schedule:
+    # Hourly: lightweight download snapshot
+    - cron: '0 * * * *'
+  workflow_dispatch: # Allow manual trigger (runs full collection)
+
+permissions:
+  contents: write
+
+jobs:
+  collect-stats:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout traffic-stats branch
+        uses: actions/checkout@v4
+        with:
+          ref: traffic-stats
+          fetch-depth: 0
+        continue-on-error: true
+
+      - name: Create branch if it doesn't exist
+        run: |
+          if ! git rev-parse --verify traffic-stats >/dev/null 2>&1; then
+            git checkout --orphan traffic-stats
+            git rm -rf . 2>/dev/null || true
+            echo "# Traffic Stats" > README.md
+            echo "This branch contains archived traffic data for this repository." >> README.md
+            echo "" >> README.md
+            echo "Hourly download tracking + full dashboard every 6 hours." >> README.md
+            echo "See [SUMMARY.md](.github/traffic/SUMMARY.md) for the latest dashboard." >> README.md
+            git add README.md
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git commit -m "chore: Initialize traffic-stats branch"
+            git push origin traffic-stats
+          fi
+
+      - name: Determine collection mode
+        id: mode
+        run: |
+          HOUR=$(date -u +%H)
+          # Full collection at 00, 06, 12, 18 UTC and on manual trigger
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || \
+             [ "$HOUR" = "00" ] || [ "$HOUR" = "06" ] || \
+             [ "$HOUR" = "12" ] || [ "$HOUR" = "18" ]; then
+            echo "full=true" >> $GITHUB_OUTPUT
+            echo "Mode: FULL collection (hour=$HOUR)"
+          else
+            echo "full=false" >> $GITHUB_OUTPUT
+            echo "Mode: DOWNLOAD-ONLY snapshot (hour=$HOUR)"
+          fi
+
+      # ── Always: Hourly download snapshot ────────────────────────
+      - name: Snapshot release downloads
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        run: |
+          mkdir -p .github/traffic/charts
+
+          TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+          # Fetch release download counts WITH publish dates
+          RELEASES=$(gh api repos/${{ github.repository }}/releases \
+            --jq '[.[] | {tag: .tag_name, published_at: .published_at, assets: [.assets[] | {name: .name, downloads: .download_count}]}]' \
+            2>/dev/null || echo '[]')
+
+          TOTAL_DL=$(echo "$RELEASES" | jq '[.[].assets[].downloads] | add // 0')
+
+          # Store/update release timeline (maps release tags to their publish dates)
+          RELEASES_TIMELINE=".github/traffic/releases_timeline.json"
+          if [ -f "$RELEASES_TIMELINE" ]; then
+            RT_EXISTING=$(cat "$RELEASES_TIMELINE")
+          else
+            RT_EXISTING='{}'
+          fi
+          # Merge current release data into timeline (preserves historical releases)
+          # Also tracks peak download count per release (survives release deletion)
+          RT_UPDATED=$(echo "$RELEASES" | jq --argjson existing "$RT_EXISTING" '
+            reduce .[] as $r ($existing;
+              ($r.assets | map(.downloads) | add // 0) as $dl |
+              .[$r.tag] = {
+                published_at: $r.published_at,
+                tag: $r.tag,
+                peak_downloads: ([($dl), (.[$r.tag].peak_downloads // 0)] | max)
+              }
+            )
+          ')
+          echo "$RT_UPDATED" > "$RELEASES_TIMELINE"
+
+          # Append to downloads timeline
+          DOWNLOADS_FILE=".github/traffic/downloads.json"
+          if [ -f "$DOWNLOADS_FILE" ]; then
+            DL_EXISTING=$(cat "$DOWNLOADS_FILE")
+          else
+            DL_EXISTING="[]"
+          fi
+
+          # Only append if total changed (avoid duplicate flat-line entries)
+          LAST_TOTAL=$(echo "$DL_EXISTING" | jq '.[-1].total_downloads // -1')
+
+          if [ "$TOTAL_DL" != "$LAST_TOTAL" ] || [ "$DL_EXISTING" = "[]" ]; then
+            DL_UPDATED=$(echo "$DL_EXISTING" | jq \
+              --arg ts "$TIMESTAMP" \
+              --argjson total "$TOTAL_DL" \
+              --argjson releases "$RELEASES" \
+              '. + [{timestamp: $ts, total_downloads: $total, per_release: $releases}]')
+            echo "$DL_UPDATED" > "$DOWNLOADS_FILE"
+            echo "Download snapshot saved: $TOTAL_DL total (changed from $LAST_TOTAL)"
+          else
+            # Still save a heartbeat entry every 6 hours even if unchanged
+            HOUR=$(date -u +%H)
+            if [ "$HOUR" = "00" ] || [ "$HOUR" = "06" ] || \
+               [ "$HOUR" = "12" ] || [ "$HOUR" = "18" ]; then
+              DL_UPDATED=$(echo "$DL_EXISTING" | jq \
+                --arg ts "$TIMESTAMP" \
+                --argjson total "$TOTAL_DL" \
+                --argjson releases "$RELEASES" \
+                '. + [{timestamp: $ts, total_downloads: $total, per_release: $releases}]')
+              echo "$DL_UPDATED" > "$DOWNLOADS_FILE"
+              echo "Heartbeat snapshot saved: $TOTAL_DL total (unchanged, 6hr checkpoint)"
+            else
+              echo "No change in downloads ($TOTAL_DL) — skipping snapshot"
+            fi
+          fi
+
+      # ── Full collection: every 6 hours ──────────────────────────
+      - name: Collect full traffic stats
+        if: steps.mode.outputs.full == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        run: |
+          TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          DATE=$(date -u +%Y-%m-%d)
+
+          # ── Fetch all API data ──
+          VIEWS=$(gh api repos/${{ github.repository }}/traffic/views 2>/dev/null || echo '{"count":0,"uniques":0,"views":[]}')
+          CLONES=$(gh api repos/${{ github.repository }}/traffic/clones 2>/dev/null || echo '{"count":0,"uniques":0,"clones":[]}')
+          REFERRERS=$(gh api repos/${{ github.repository }}/traffic/popular/referrers 2>/dev/null || echo '[]')
+          PATHS=$(gh api repos/${{ github.repository }}/traffic/popular/paths 2>/dev/null || echo '[]')
+          RELEASES=$(gh api repos/${{ github.repository }}/releases --jq '[.[] | {tag: .tag_name, assets: [.assets[] | {name: .name, downloads: .download_count}]}]' 2>/dev/null || echo '[]')
+          STARGAZERS=$(gh api repos/${{ github.repository }} --jq '.stargazers_count' 2>/dev/null || echo '0')
+          FORKS=$(gh api repos/${{ github.repository }} --jq '.forks_count' 2>/dev/null || echo '0')
+          WATCHERS=$(gh api repos/${{ github.repository }} --jq '.subscribers_count' 2>/dev/null || echo '0')
+          OPEN_ISSUES=$(gh api repos/${{ github.repository }} --jq '.open_issues_count' 2>/dev/null || echo '0')
+
+          # ── Daily views/clones (preserved beyond 14-day window) ──
+          DAILY_FILE=".github/traffic/daily.json"
+          if [ -f "$DAILY_FILE" ]; then
+            DAILY_EXISTING=$(cat "$DAILY_FILE")
+          else
+            DAILY_EXISTING='{}'
+          fi
+
+          DAILY_UPDATED=$(echo "$VIEWS" | jq --argjson clones "$CLONES" --argjson existing "$DAILY_EXISTING" '
+            $existing as $base |
+            reduce (.views[]? // empty) as $v ($base;
+              ($v.timestamp | split("T")[0]) as $day |
+              .[$day] = (.[$day] // {}) |
+              .[$day].views_total = $v.count |
+              .[$day].views_unique = $v.uniques
+            ) |
+            reduce ($clones.clones[]? // empty) as $c (.;
+              ($c.timestamp | split("T")[0]) as $day |
+              .[$day] = (.[$day] // {}) |
+              .[$day].clones_total = $c.count |
+              .[$day].clones_unique = $c.uniques
+            )
+          ')
+          echo "$DAILY_UPDATED" > "$DAILY_FILE"
+
+          # ── Referrer history (one snapshot per day) ──
+          REFERRER_FILE=".github/traffic/referrers.json"
+          if [ -f "$REFERRER_FILE" ]; then
+            REF_EXISTING=$(cat "$REFERRER_FILE")
+          else
+            REF_EXISTING='{}'
+          fi
+          REF_UPDATED=$(echo "$REF_EXISTING" | jq --arg date "$DATE" --argjson refs "$REFERRERS" '.[$date] = $refs')
+          echo "$REF_UPDATED" > "$REFERRER_FILE"
+
+          # ── Repo metadata (one snapshot per day) ──
+          META_FILE=".github/traffic/metadata.json"
+          if [ -f "$META_FILE" ]; then
+            META_EXISTING=$(cat "$META_FILE")
+          else
+            META_EXISTING="[]"
+          fi
+
+          META_UPDATED=$(echo "$META_EXISTING" | jq --arg date "$DATE" \
+            --argjson stars "$STARGAZERS" --argjson forks "$FORKS" \
+            --argjson watchers "$WATCHERS" --argjson issues "$OPEN_ISSUES" \
+            '[.[] | select(.date != $date)] + [{
+              date: $date, stars: $stars, forks: $forks,
+              watchers: $watchers, open_issues: $issues
+            }] | sort_by(.date)')
+          echo "$META_UPDATED" > "$META_FILE"
+
+          # ── Legacy combined snapshot ──
+          STATS_FILE=".github/traffic/stats.json"
+          if [ -f "$STATS_FILE" ]; then
+            EXISTING=$(cat "$STATS_FILE")
+          else
+            EXISTING="[]"
+          fi
+
+          TODAY_SNAPSHOT=$(jq -n \
+            --arg ts "$TIMESTAMP" --arg date "$DATE" \
+            --argjson views "$VIEWS" --argjson clones "$CLONES" \
+            --argjson referrers "$REFERRERS" --argjson paths "$PATHS" \
+            --argjson releases "$RELEASES" --argjson stars "$STARGAZERS" \
+            --argjson forks "$FORKS" --argjson watchers "$WATCHERS" \
+            '{
+              timestamp: $ts, date: $date,
+              views: { count: $views.count, uniques: $views.uniques },
+              clones: { count: $clones.count, uniques: $clones.uniques },
+              referrers: $referrers, popular_paths: $paths,
+              releases: $releases,
+              stars: $stars, forks: $forks, watchers: $watchers
+            }')
+
+          UPDATED=$(echo "$EXISTING" | jq --arg date "$DATE" --argjson snapshot "$TODAY_SNAPSHOT" \
+            '[.[] | select(.date != $date)] + [$snapshot] | sort_by(.date)')
+          echo "$UPDATED" > "$STATS_FILE"
+
+      # ── Charts: only on full collection ─────────────────────────
+      - name: Set up Python
+        if: steps.mode.outputs.full == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install charting dependencies
+        if: steps.mode.outputs.full == 'true'
+        run: pip install matplotlib
+
+      - name: Generate charts
+        if: steps.mode.outputs.full == 'true'
+        run: |
+          python3 << 'PYEOF'
+          import json
+          import os
+          from datetime import datetime, timedelta
+
+          import matplotlib
+          matplotlib.use('Agg')
+          import matplotlib.pyplot as plt
+          import matplotlib.dates as mdates
+
+          TRAFFIC_DIR = ".github/traffic"
+          CHARTS_DIR = os.path.join(TRAFFIC_DIR, "charts")
+          os.makedirs(CHARTS_DIR, exist_ok=True)
+
+          # ── Shared dark theme (GitHub style) ──
+          plt.rcParams.update({
+              'figure.facecolor': '#0d1117',
+              'axes.facecolor': '#161b22',
+              'axes.edgecolor': '#30363d',
+              'axes.labelcolor': '#c9d1d9',
+              'text.color': '#c9d1d9',
+              'xtick.color': '#8b949e',
+              'ytick.color': '#8b949e',
+              'grid.color': '#21262d',
+              'grid.alpha': 0.8,
+              'font.size': 11,
+          })
+
+          # ── Chart 1: Views & Clones ──
+          daily_file = os.path.join(TRAFFIC_DIR, "daily.json")
+          if os.path.exists(daily_file):
+              with open(daily_file) as f:
+                  daily = json.load(f)
+
+              if daily:
+                  dates = sorted(daily.keys())
+                  date_objs = [datetime.strptime(d, "%Y-%m-%d") for d in dates]
+                  views = [daily[d].get("views_total", 0) or 0 for d in dates]
+                  views_uniq = [daily[d].get("views_unique", 0) or 0 for d in dates]
+                  clones = [daily[d].get("clones_total", 0) or 0 for d in dates]
+                  clones_uniq = [daily[d].get("clones_unique", 0) or 0 for d in dates]
+
+                  fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(12, 8), sharex=True)
+                  fig.suptitle("Repository Traffic Dashboard", fontsize=16, fontweight='bold', color='#58a6ff')
+
+                  ax1.fill_between(date_objs, views, alpha=0.3, color='#58a6ff')
+                  ax1.plot(date_objs, views, 'o-', color='#58a6ff', linewidth=2, markersize=5, label='Total Views')
+                  ax1.plot(date_objs, views_uniq, 's--', color='#3fb950', linewidth=1.5, markersize=4, label='Unique Visitors')
+                  ax1.set_ylabel("Page Views")
+                  ax1.legend(loc='upper left', framealpha=0.8)
+                  ax1.grid(True, linestyle='--')
+                  ax1.set_ylim(bottom=0)
+
+                  ax2.fill_between(date_objs, clones, alpha=0.3, color='#d29922')
+                  ax2.plot(date_objs, clones, 'o-', color='#d29922', linewidth=2, markersize=5, label='Total Clones')
+                  ax2.plot(date_objs, clones_uniq, 's--', color='#f85149', linewidth=1.5, markersize=4, label='Unique Cloners')
+                  ax2.set_ylabel("Git Clones")
+                  ax2.legend(loc='upper left', framealpha=0.8)
+                  ax2.grid(True, linestyle='--')
+                  ax2.set_ylim(bottom=0)
+
+                  ax2.xaxis.set_major_formatter(mdates.DateFormatter('%b %d'))
+                  ax2.xaxis.set_major_locator(mdates.DayLocator(interval=2))
+                  plt.xticks(rotation=45)
+                  fig.tight_layout()
+                  fig.savefig(os.path.join(CHARTS_DIR, "views_clones.png"), dpi=150, bbox_inches='tight')
+                  plt.close()
+                  print("Generated: views_clones.png")
+
+          # ── Chart 2: Total Acquisition per Release Era ──
+          # Combines zip downloads + git clones, attributed to whichever
+          # release was current at the time
+          dl_file = os.path.join(TRAFFIC_DIR, "downloads.json")
+          rt_file = os.path.join(TRAFFIC_DIR, "releases_timeline.json")
+
+          # Load release timeline (tag → publish date + peak downloads)
+          release_eras = []
+          rt = {}
+          if os.path.exists(rt_file):
+              with open(rt_file) as f:
+                  rt = json.load(f)
+              for tag, info in rt.items():
+                  pub = info.get("published_at")
+                  if pub:
+                      release_eras.append({
+                          "tag": tag,
+                          "start": datetime.strptime(pub.split("T")[0], "%Y-%m-%d"),
+                          "peak_downloads": info.get("peak_downloads", 0)
+                      })
+              release_eras.sort(key=lambda r: r["start"])
+
+          # Load daily clones
+          daily_clones = {}
+          if os.path.exists(daily_file):
+              with open(daily_file) as f:
+                  daily = json.load(f)
+              for d, vals in daily.items():
+                  daily_clones[d] = vals.get("clones_total", 0) or 0
+
+          # Load download snapshots
+          downloads = []
+          if os.path.exists(dl_file):
+              with open(dl_file) as f:
+                  downloads = json.load(f)
+
+          # Helper: which release era does a date belong to?
+          def get_release_era(date_obj):
+              current_tag = None
+              for era in release_eras:
+                  if date_obj >= era["start"]:
+                      current_tag = era["tag"]
+              return current_tag or (release_eras[0]["tag"] if release_eras else "pre-release")
+
+          # Build per-release-era acquisition totals
+          era_colors = ['#3fb950', '#58a6ff', '#d29922', '#f85149', '#bc8cff',
+                        '#56d364', '#79c0ff', '#e3b341', '#ff7b72', '#d2a8ff']
+
+          if release_eras and (daily_clones or downloads):
+              # Aggregate clones per era from daily data
+              era_clones = {}
+              era_clone_days = {}  # track daily breakdown for chart
+              for date_str, clone_count in sorted(daily_clones.items()):
+                  date_obj = datetime.strptime(date_str, "%Y-%m-%d")
+                  era_tag = get_release_era(date_obj)
+                  era_clones[era_tag] = era_clones.get(era_tag, 0) + clone_count
+                  if era_tag not in era_clone_days:
+                      era_clone_days[era_tag] = []
+                  era_clone_days[era_tag].append((date_obj, clone_count))
+
+              # Get latest download total per release from most recent snapshot
+              era_downloads = {}
+              if downloads:
+                  latest = downloads[-1]
+                  for rel in (latest.get("per_release") or latest.get("releases", [])):
+                      era_downloads[rel["tag"]] = sum(a["downloads"] for a in rel.get("assets", []))
+
+              # Fallback: use peak_downloads from timeline for deleted releases
+              for era in release_eras:
+                  if era["tag"] not in era_downloads and era.get("peak_downloads", 0) > 0:
+                      era_downloads[era["tag"]] = era["peak_downloads"]
+
+              # ── Main chart: stacked bars per release era ──
+              tags = [era["tag"] for era in release_eras]
+              clone_vals = [era_clones.get(t, 0) for t in tags]
+              dl_vals = [era_downloads.get(t, 0) for t in tags]
+              total_vals = [c + d for c, d in zip(clone_vals, dl_vals)]
+
+              fig, (ax_bars, ax_timeline) = plt.subplots(2, 1, figsize=(12, 9),
+                  gridspec_kw={'height_ratios': [1, 1.2]})
+              fig.suptitle("Total Acquisition per Release", fontsize=16, fontweight='bold', color='#58a6ff')
+
+              # Top: stacked bar chart per release
+              x = list(range(len(tags)))
+              bar_w = 0.5
+              bars_clones = ax_bars.bar(x, clone_vals, bar_w, color='#3fb950', alpha=0.8, label='Git Clones')
+              bars_dls = ax_bars.bar(x, dl_vals, bar_w, bottom=clone_vals, color='#d29922', alpha=0.8, label='Zip Downloads')
+
+              ax_bars.set_xticks(x)
+              ax_bars.set_xticklabels(tags, fontsize=11)
+              ax_bars.set_ylabel("Total Acquisitions")
+              ax_bars.legend(loc='upper left', framealpha=0.8)
+              ax_bars.grid(True, axis='y', linestyle='--')
+              ax_bars.set_ylim(bottom=0)
+
+              # Value labels on bars
+              for i, (ct, dt, tt) in enumerate(zip(clone_vals, dl_vals, total_vals)):
+                  # Clone count inside green bar
+                  if ct > 0:
+                      ax_bars.text(i, ct/2, f'{ct} clones', ha='center', va='center',
+                                   fontsize=10, color='white', fontweight='bold')
+                  # Download count inside gold bar
+                  if dt > 0:
+                      ax_bars.text(i, ct + dt/2, f'{dt} zips', ha='center', va='center',
+                                   fontsize=10, color='white', fontweight='bold')
+                  # Total on top
+                  ax_bars.text(i, tt + max(total_vals)*0.02, str(tt), ha='center',
+                               fontsize=12, fontweight='bold', color='#c9d1d9')
+
+              # Bottom: daily clones timeline with release era shading
+              all_dates = sorted(daily_clones.keys())
+              if all_dates:
+                  date_objs = [datetime.strptime(d, "%Y-%m-%d") for d in all_dates]
+                  clone_series = [daily_clones.get(d, 0) for d in all_dates]
+
+                  ax_timeline.bar(date_objs, clone_series, width=0.8, color='#3fb950', alpha=0.6, label='Daily Clones')
+
+                  # Shade release eras with colors + labels
+                  for i, era in enumerate(release_eras):
+                      era_start = era["start"]
+                      # Era ends when next release starts, or today
+                      if i + 1 < len(release_eras):
+                          era_end = release_eras[i+1]["start"]
+                      else:
+                          era_end = max(date_objs) + timedelta(days=1)
+                      color = era_colors[i % len(era_colors)]
+                      ax_timeline.axvspan(era_start, era_end, alpha=0.08, color=color)
+                      # Label at top of shaded region
+                      mid = era_start + (era_end - era_start) / 2
+                      ax_timeline.text(mid, ax_timeline.get_ylim()[1] if ax_timeline.get_ylim()[1] > 0 else max(clone_series) * 0.95,
+                                       era["tag"], ha='center', va='top', fontsize=10,
+                                       color=color, fontweight='bold', alpha=0.9)
+                      # Vertical line at release boundary
+                      ax_timeline.axvline(x=era_start, color=color, linestyle='--', alpha=0.5, linewidth=1)
+
+                  ax_timeline.set_ylabel("Daily Git Clones")
+                  ax_timeline.set_xlabel("")
+                  ax_timeline.grid(True, axis='y', linestyle='--')
+                  ax_timeline.set_ylim(bottom=0)
+                  ax_timeline.xaxis.set_major_formatter(mdates.DateFormatter('%b %d'))
+                  ax_timeline.xaxis.set_major_locator(mdates.DayLocator(interval=2))
+                  plt.xticks(rotation=45)
+
+              fig.tight_layout()
+              fig.savefig(os.path.join(CHARTS_DIR, "downloads.png"), dpi=150, bbox_inches='tight')
+              plt.close()
+
+              total_all = sum(total_vals)
+              print(f"Generated: downloads.png ({len(tags)} releases, {total_all} total acquisitions)")
+
+          elif downloads:
+              # No release timeline yet — fallback to simple download chart
+              if len(downloads) >= 2:
+                  timestamps = [datetime.strptime(d["timestamp"], "%Y-%m-%dT%H:%M:%SZ") for d in downloads]
+                  totals = [d["total_downloads"] for d in downloads]
+
+                  fig, ax = plt.subplots(figsize=(12, 4))
+                  fig.suptitle("Release Downloads", fontsize=14, fontweight='bold', color='#58a6ff')
+                  ax.fill_between(timestamps, totals, alpha=0.2, color='#3fb950')
+                  ax.plot(timestamps, totals, 'o-', color='#3fb950', linewidth=2, markersize=4)
+                  ax.set_ylabel("Total Downloads")
+                  ax.set_ylim(bottom=0)
+                  ax.grid(True, linestyle='--')
+                  ax.xaxis.set_major_formatter(mdates.DateFormatter('%b %d %H:%M'))
+                  plt.xticks(rotation=45)
+                  fig.tight_layout()
+                  fig.savefig(os.path.join(CHARTS_DIR, "downloads.png"), dpi=150, bbox_inches='tight')
+                  plt.close()
+                  print(f"Generated: downloads.png (fallback, {len(downloads)} snapshots)")
+
+              elif len(downloads) == 1:
+                  d = downloads[0]
+                  total = d["total_downloads"]
+                  releases = d.get("per_release") or d.get("releases", [])
+                  labels, values = [], []
+                  for rel in releases:
+                      for asset in rel.get("assets", []):
+                          labels.append(f'{rel.get("tag","?")}\n{asset["name"]}')
+                          values.append(asset["downloads"])
+                  if not labels:
+                      labels, values = ["Total"], [total]
+
+                  fig, ax = plt.subplots(figsize=(8, 4))
+                  fig.suptitle("Release Downloads", fontsize=14, fontweight='bold', color='#58a6ff')
+                  bars = ax.bar(labels, values, color='#3fb950', width=0.4)
+                  ax.set_ylabel("Downloads")
+                  ax.grid(True, axis='y', linestyle='--')
+                  ax.set_ylim(bottom=0)
+                  for bar, val in zip(bars, values):
+                      ax.text(bar.get_x() + bar.get_width()/2, bar.get_height() + 0.3,
+                              str(val), ha='center', fontsize=14, fontweight='bold', color='#3fb950')
+                  fig.tight_layout()
+                  fig.savefig(os.path.join(CHARTS_DIR, "downloads.png"), dpi=150, bbox_inches='tight')
+                  plt.close()
+                  print(f"Generated: downloads.png (single snapshot: {total})")
+
+          # ── Chart 3: Referrers ──
+          ref_file = os.path.join(TRAFFIC_DIR, "referrers.json")
+          if os.path.exists(ref_file):
+              with open(ref_file) as f:
+                  referrers = json.load(f)
+
+              if referrers:
+                  latest_date = sorted(referrers.keys())[-1]
+                  refs = referrers[latest_date]
+
+                  if refs:
+                      names = [r["referrer"] for r in refs]
+                      counts = [r["count"] for r in refs]
+                      colors = ['#58a6ff', '#3fb950', '#d29922', '#f85149', '#bc8cff',
+                                '#79c0ff', '#56d364', '#e3b341', '#ff7b72', '#d2a8ff']
+
+                      fig, ax = plt.subplots(figsize=(8, 5))
+                      fig.suptitle(f"Traffic Referrers ({latest_date})", fontsize=14, fontweight='bold', color='#58a6ff')
+                      bars = ax.barh(names[::-1], counts[::-1], color=colors[:len(names)][::-1])
+                      ax.set_xlabel("Page Views")
+                      ax.grid(True, axis='x', linestyle='--')
+
+                      for bar, count in zip(bars, counts[::-1]):
+                          ax.text(bar.get_width() + max(counts)*0.02, bar.get_y() + bar.get_height()/2,
+                                  str(count), va='center', color='#c9d1d9', fontsize=10)
+
+                      fig.tight_layout()
+                      fig.savefig(os.path.join(CHARTS_DIR, "referrers.png"), dpi=150, bbox_inches='tight')
+                      plt.close()
+                      print("Generated: referrers.png")
+
+          # ── Chart 4: Stars/Forks growth (always line chart) ──
+          meta_file = os.path.join(TRAFFIC_DIR, "metadata.json")
+          if os.path.exists(meta_file):
+              with open(meta_file) as f:
+                  metadata = json.load(f)
+
+              if metadata:
+                  dates = [datetime.strptime(m["date"], "%Y-%m-%d") for m in metadata]
+                  stars = [m.get("stars", 0) for m in metadata]
+                  forks = [m.get("forks", 0) for m in metadata]
+                  watchers = [m.get("watchers", 0) for m in metadata]
+
+                  fig, ax = plt.subplots(figsize=(12, 4))
+                  fig.suptitle("Repository Growth", fontsize=14, fontweight='bold', color='#58a6ff')
+                  ax.plot(dates, stars, 'o-', color='#d29922', linewidth=2, markersize=6, label='Stars')
+                  ax.plot(dates, forks, 's-', color='#58a6ff', linewidth=2, markersize=5, label='Forks')
+                  ax.plot(dates, watchers, '^-', color='#3fb950', linewidth=2, markersize=5, label='Watchers')
+                  ax.set_ylabel("Count")
+                  ax.legend(loc='upper left', framealpha=0.8)
+                  ax.grid(True, linestyle='--')
+                  ax.set_ylim(bottom=0)
+                  ax.xaxis.set_major_formatter(mdates.DateFormatter('%b %d'))
+                  # Explicitly set ticks to actual dates (auto-locator misses with few points)
+                  ax.set_xticks(dates)
+                  plt.xticks(rotation=45)
+
+                  # Value labels at each point
+                  for d, s, f, w in zip(dates, stars, forks, watchers):
+                      ax.annotate(str(s), (d, s), textcoords="offset points",
+                                  xytext=(0, 8), ha='center', fontsize=9, color='#d29922', fontweight='bold')
+                      if f > 0:
+                          ax.annotate(str(f), (d, f), textcoords="offset points",
+                                      xytext=(0, 8), ha='center', fontsize=9, color='#58a6ff', fontweight='bold')
+                      if w > 0:
+                          ax.annotate(str(w), (d, w), textcoords="offset points",
+                                      xytext=(0, -14), ha='center', fontsize=9, color='#3fb950', fontweight='bold')
+
+                  fig.tight_layout()
+                  fig.savefig(os.path.join(CHARTS_DIR, "growth.png"), dpi=150, bbox_inches='tight')
+                  plt.close()
+                  print(f"Generated: growth.png ({len(metadata)} data points)")
+
+          # ── Chart 5: Engagement (pages per visitor) ──
+          if os.path.exists(daily_file):
+              with open(daily_file) as f:
+                  daily = json.load(f)
+
+              if daily:
+                  dates = sorted(daily.keys())
+                  date_objs = [datetime.strptime(d, "%Y-%m-%d") for d in dates]
+                  views = [daily[d].get("views_total", 0) or 0 for d in dates]
+                  uniques = [daily[d].get("views_unique", 0) or 0 for d in dates]
+                  pages_per_visitor = [v / u if u > 0 else 0 for v, u in zip(views, uniques)]
+
+                  fig, ax1 = plt.subplots(figsize=(12, 6))
+                  fig.suptitle("Visitor Engagement — Are People Exploring?",
+                               fontsize=15, fontweight='bold', color='#58a6ff')
+
+                  # Stacked area: unique visitors vs total views
+                  ax1.fill_between(date_objs, uniques, alpha=0.4, color='#3fb950', label='Unique Visitors')
+                  ax1.fill_between(date_objs, views, alpha=0.2, color='#58a6ff', label='Total Page Views')
+                  ax1.plot(date_objs, views, '-', color='#58a6ff', linewidth=1.5, alpha=0.7)
+                  ax1.plot(date_objs, uniques, '-', color='#3fb950', linewidth=1.5, alpha=0.7)
+                  ax1.set_ylabel("Count", color='#c9d1d9')
+                  ax1.set_ylim(bottom=0)
+                  ax1.grid(True, linestyle='--')
+
+                  # Pages per visitor on secondary axis
+                  ax2 = ax1.twinx()
+                  ax2.plot(date_objs, pages_per_visitor, 'D-', color='#d29922', linewidth=2.5,
+                           markersize=7, label='Pages / Visitor', zorder=5)
+                  ax2.set_ylabel("Avg Pages per Visitor", color='#d29922')
+                  ax2.set_ylim(bottom=0)
+
+                  # Add value labels on the engagement line
+                  for i, (d, ppv) in enumerate(zip(date_objs, pages_per_visitor)):
+                      if ppv > 0:
+                          ax2.annotate(f'{ppv:.1f}', (d, ppv),
+                                       textcoords="offset points", xytext=(0, 10),
+                                       ha='center', fontsize=9, color='#d29922', fontweight='bold')
+
+                  # Average engagement line
+                  valid_ppv = [p for p in pages_per_visitor if p > 0]
+                  if valid_ppv:
+                      avg_ppv = sum(valid_ppv) / len(valid_ppv)
+                      ax2.axhline(y=avg_ppv, color='#d29922', linestyle=':', alpha=0.5, linewidth=1)
+                      ax2.text(date_objs[-1], avg_ppv, f'  avg: {avg_ppv:.1f}',
+                               va='bottom', color='#d29922', fontsize=9, alpha=0.7)
+
+                  # Combine legends
+                  lines1, labels1 = ax1.get_legend_handles_labels()
+                  lines2, labels2 = ax2.get_legend_handles_labels()
+                  ax1.legend(lines1 + lines2, labels1 + labels2, loc='upper left', framealpha=0.8)
+
+                  ax1.xaxis.set_major_formatter(mdates.DateFormatter('%b %d'))
+                  ax1.xaxis.set_major_locator(mdates.DayLocator(interval=2))
+                  plt.xticks(rotation=45)
+                  fig.tight_layout()
+                  fig.savefig(os.path.join(CHARTS_DIR, "engagement.png"), dpi=150, bbox_inches='tight')
+                  plt.close()
+                  print(f"Generated: engagement.png (avg {avg_ppv:.1f} pages/visitor)" if valid_ppv else "Generated: engagement.png")
+
+          # ── Chart 6: Conversion funnel (visitor → clone/download) ──
+          if os.path.exists(daily_file):
+              with open(daily_file) as f:
+                  daily = json.load(f)
+
+              # Compute daily download deltas from cumulative snapshots
+              daily_dl_deltas = {}
+              if os.path.exists(dl_file):
+                  with open(dl_file) as f:
+                      downloads = json.load(f)
+                  if len(downloads) >= 2:
+                      for i in range(1, len(downloads)):
+                          prev = downloads[i-1]
+                          curr = downloads[i]
+                          delta = max(0, curr["total_downloads"] - prev["total_downloads"])
+                          if delta > 0:
+                              day = curr["timestamp"].split("T")[0]
+                              daily_dl_deltas[day] = daily_dl_deltas.get(day, 0) + delta
+
+              if daily:
+                  dates = sorted(daily.keys())
+                  date_objs = [datetime.strptime(d, "%Y-%m-%d") for d in dates]
+                  visitors = [daily[d].get("views_unique", 0) or 0 for d in dates]
+                  cloners = [daily[d].get("clones_unique", 0) or 0 for d in dates]
+                  dls = [daily_dl_deltas.get(d, 0) for d in dates]
+                  # Combined acquisitions = unique cloners + download deltas
+                  acquisitions = [c + dl for c, dl in zip(cloners, dls)]
+                  # Conversion rate
+                  conversion = [a / v * 100 if v > 0 else 0 for a, v in zip(acquisitions, visitors)]
+
+                  fig, ax1 = plt.subplots(figsize=(12, 6))
+                  fig.suptitle("Conversion Funnel — Visitors Who Download",
+                               fontsize=15, fontweight='bold', color='#58a6ff')
+
+                  # Grouped bars: visitors vs acquisitions
+                  bar_width = 0.35
+                  x_indices = list(range(len(dates)))
+                  x_visitors = [x - bar_width/2 for x in x_indices]
+                  x_acquired = [x + bar_width/2 for x in x_indices]
+
+                  ax1.bar(x_visitors, visitors, bar_width, color='#58a6ff', alpha=0.7, label='Unique Visitors')
+                  # Stack clones and downloads in the acquired bar
+                  ax1.bar(x_acquired, cloners, bar_width, color='#3fb950', alpha=0.8, label='Unique Cloners')
+                  if any(dl > 0 for dl in dls):
+                      ax1.bar(x_acquired, dls, bar_width, bottom=cloners, color='#d29922', alpha=0.8, label='Release Downloads')
+
+                  ax1.set_ylabel("People")
+                  ax1.set_ylim(bottom=0)
+                  ax1.grid(True, axis='y', linestyle='--')
+
+                  # X-axis labels
+                  ax1.set_xticks(x_indices)
+                  short_dates = [datetime.strptime(d, "%Y-%m-%d").strftime('%b %d') for d in dates]
+                  ax1.set_xticklabels(short_dates, rotation=45, ha='right')
+
+                  # Conversion rate line on secondary axis
+                  ax2 = ax1.twinx()
+                  ax2.plot(x_indices, conversion, 'D-', color='#f85149', linewidth=2.5,
+                           markersize=8, label='Conversion %', zorder=5)
+                  ax2.set_ylabel("Conversion Rate %", color='#f85149')
+                  ax2.set_ylim(bottom=0, top=max(max(conversion) * 1.3, 10) if conversion else 100)
+
+                  # Value labels on conversion points
+                  for x, pct in zip(x_indices, conversion):
+                      if pct > 0:
+                          ax2.annotate(f'{pct:.0f}%', (x, pct),
+                                       textcoords="offset points", xytext=(0, 12),
+                                       ha='center', fontsize=10, color='#f85149', fontweight='bold')
+
+                  # Average conversion line
+                  valid_conv = [c for c in conversion if c > 0]
+                  if valid_conv:
+                      avg_conv = sum(valid_conv) / len(valid_conv)
+                      ax2.axhline(y=avg_conv, color='#f85149', linestyle=':', alpha=0.4, linewidth=1)
+                      ax2.text(x_indices[-1] + 0.1, avg_conv, f' avg: {avg_conv:.0f}%',
+                               va='center', color='#f85149', fontsize=9, alpha=0.7)
+
+                  # Combine legends
+                  lines1, labels1 = ax1.get_legend_handles_labels()
+                  lines2, labels2 = ax2.get_legend_handles_labels()
+                  ax1.legend(lines1 + lines2, labels1 + labels2, loc='upper left', framealpha=0.8)
+
+                  fig.tight_layout()
+                  fig.savefig(os.path.join(CHARTS_DIR, "conversion.png"), dpi=150, bbox_inches='tight')
+                  plt.close()
+
+                  # Print summary
+                  total_visitors = sum(visitors)
+                  total_acquired = sum(acquisitions)
+                  overall_conv = (total_acquired / total_visitors * 100) if total_visitors > 0 else 0
+                  print(f"Generated: conversion.png ({overall_conv:.0f}% overall conversion)")
+
+          print("Chart generation complete!")
+          PYEOF
+
+      # ── Summary: only on full collection ────────────────────────
+      - name: Generate summary dashboard
+        if: steps.mode.outputs.full == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        run: |
+          SUMMARY_FILE=".github/traffic/SUMMARY.md"
+          DATE=$(date -u +%Y-%m-%d)
+          TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+          VIEWS=$(gh api repos/${{ github.repository }}/traffic/views 2>/dev/null || echo '{"count":0,"uniques":0}')
+          CLONES=$(gh api repos/${{ github.repository }}/traffic/clones 2>/dev/null || echo '{"count":0,"uniques":0}')
+          REFERRERS=$(gh api repos/${{ github.repository }}/traffic/popular/referrers 2>/dev/null || echo '[]')
+          PATHS=$(gh api repos/${{ github.repository }}/traffic/popular/paths 2>/dev/null || echo '[]')
+          # Read download total from our own data (gh api --jq has issues with nested arrays)
+          TOTAL_DL=$(jq '.[-1].total_downloads // 0' .github/traffic/downloads.json 2>/dev/null || echo '0')
+          STARGAZERS=$(gh api repos/${{ github.repository }} --jq '.stargazers_count' 2>/dev/null || echo '0')
+          FORKS=$(gh api repos/${{ github.repository }} --jq '.forks_count' 2>/dev/null || echo '0')
+          WATCHERS=$(gh api repos/${{ github.repository }} --jq '.subscribers_count' 2>/dev/null || echo '0')
+
+          DAYS_TRACKED=$(jq 'length' .github/traffic/metadata.json 2>/dev/null || echo '1')
+          DL_SNAPSHOTS=$(jq 'length' .github/traffic/downloads.json 2>/dev/null || echo '1')
+
+          {
+            echo "# Repository Traffic Dashboard"
+            echo ""
+            echo "**Last updated:** ${TIMESTAMP}"
+            echo "**Days tracked:** ${DAYS_TRACKED} | **Download snapshots:** ${DL_SNAPSHOTS} (hourly)"
+            echo ""
+            echo "---"
+            echo ""
+            echo "## Views & Clones (14-day window, preserved forever)"
+            echo ""
+            echo "![Views & Clones](charts/views_clones.png)"
+            echo ""
+            echo "| Metric | 14-Day Total | Unique |"
+            echo "|--------|-------------|--------|"
+            echo "| Page Views | $(echo "$VIEWS" | jq '.count') | $(echo "$VIEWS" | jq '.uniques') |"
+            echo "| Git Clones | $(echo "$CLONES" | jq '.count') | $(echo "$CLONES" | jq '.uniques') |"
+            echo ""
+            TOTAL_VIEWS=$(echo "$VIEWS" | jq '.count')
+            UNIQUE_VISITORS=$(echo "$VIEWS" | jq '.uniques')
+            if [ "$UNIQUE_VISITORS" -gt 0 ] 2>/dev/null; then
+              AVG_PAGES=$(echo "scale=1; $TOTAL_VIEWS / $UNIQUE_VISITORS" | bc)
+              echo "> **Engagement:** ${AVG_PAGES} pages per visitor (14-day avg)"
+              echo ""
+            fi
+            echo "---"
+            echo ""
+            echo "## Visitor Engagement"
+            echo ""
+            echo "![Engagement](charts/engagement.png)"
+            echo ""
+            echo "> Higher = visitors exploring more pages. 1.0 = bounce. 3.0+ = deeply engaged."
+            echo ""
+            echo "---"
+            echo ""
+            echo "## Conversion Funnel"
+            echo ""
+            echo "![Conversion](charts/conversion.png)"
+            echo ""
+            UNIQUE_CLONERS=$(echo "$CLONES" | jq '.uniques')
+            if [ "$UNIQUE_VISITORS" -gt 0 ] 2>/dev/null; then
+              CONV_ACQUIRED=$((UNIQUE_CLONERS + TOTAL_DL))
+              CONV_PCT=$(echo "scale=1; $CONV_ACQUIRED * 100 / $UNIQUE_VISITORS" | bc)
+              echo "> **14-day conversion:** ${CONV_ACQUIRED} of ${UNIQUE_VISITORS} visitors cloned or downloaded (**${CONV_PCT}%**)"
+              echo ">"
+              echo "> Unique cloners: ${UNIQUE_CLONERS} | Release downloads: ${TOTAL_DL}"
+            fi
+            echo ""
+            echo "---"
+            echo ""
+            echo "## Total Acquisition per Release (Downloads + Clones)"
+            echo ""
+            echo "![Acquisition](charts/downloads.png)"
+            echo ""
+            TOTAL_CLONES_14D=$(echo "$CLONES" | jq '.count')
+            TOTAL_ACQUIRED=$((TOTAL_DL + TOTAL_CLONES_14D))
+            echo "| Channel | Count |"
+            echo "|---------|-------|"
+            echo "| Zip Downloads | ${TOTAL_DL} |"
+            echo "| Git Clones (14-day) | ${TOTAL_CLONES_14D} |"
+            echo "| **Total Acquisitions** | **${TOTAL_ACQUIRED}** |"
+            echo ""
+            echo "---"
+            echo ""
+            echo "## Referrers"
+            echo ""
+            echo "![Referrers](charts/referrers.png)"
+            echo ""
+            echo "| Source | Views | Unique |"
+            echo "|--------|-------|--------|"
+            echo "$REFERRERS" | jq -r '.[] | "| \(.referrer) | \(.count) | \(.uniques) |"' 2>/dev/null || echo "| No data | - | - |"
+            echo ""
+            echo "---"
+            echo ""
+            echo "## Repository Growth"
+            echo ""
+            echo "![Growth](charts/growth.png)"
+            echo ""
+            echo "| Metric | Current |"
+            echo "|--------|---------|"
+            echo "| Stars | ${STARGAZERS} |"
+            echo "| Forks | ${FORKS} |"
+            echo "| Watchers | ${WATCHERS} |"
+            echo ""
+            echo "---"
+            echo ""
+            echo "## Top Pages (14-day)"
+            echo ""
+            echo "| Page | Views | Unique |"
+            echo "|------|-------|--------|"
+            echo "$PATHS" | jq -r '.[:10][] | "| `\(.path)` | \(.count) | \(.uniques) |"' 2>/dev/null || echo "| No data | - | - |"
+            echo ""
+            echo "---"
+            echo ""
+            echo "## Data Files"
+            echo ""
+            echo "| File | Description | Granularity |"
+            echo "|------|-------------|-------------|"
+            echo "| [daily.json](daily.json) | Views & clones per day (never expires) | Daily |"
+            echo "| [downloads.json](downloads.json) | Release download snapshots | Hourly |"
+            echo "| [referrers.json](referrers.json) | Referrer snapshots | Daily |"
+            echo "| [metadata.json](metadata.json) | Stars, forks, watchers | Daily |"
+            echo "| [stats.json](stats.json) | Combined legacy snapshots | 6-hourly |"
+            echo ""
+            echo "---"
+            echo "*Hourly download tracking + full dashboard with engagement metrics every 6 hours*"
+            echo "*Auto-generated by [traffic-stats.yml](../../.github/workflows/traffic-stats.yml)*"
+          } > "$SUMMARY_FILE"
+
+      # ── Commit ──────────────────────────────────────────────────
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .github/traffic/
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            MODE="${{ steps.mode.outputs.full }}"
+            if [ "$MODE" = "true" ]; then
+              git commit -m "chore: Full traffic snapshot $(date -u +%Y-%m-%d_%H:%M)"
+            else
+              git commit -m "chore: Download snapshot $(date -u +%Y-%m-%d_%H:%M)"
+            fi
+            git push origin traffic-stats
+          fi

--- a/RandomWorldEvents.lua
+++ b/RandomWorldEvents.lua
@@ -209,7 +209,14 @@ function RandomWorldEvents:createSettingsManager()
                 settingsObject.physics.suspensionStiffness = xml:getFloat(manager.XMLTAG..".physics.suspensionStiffness", manager.defaultConfig.physics.suspensionStiffness)
                 settingsObject.physics.showPhysicsInfo = xml:getBool(manager.XMLTAG..".physics.showPhysicsInfo", manager.defaultConfig.physics.showPhysicsInfo)
                 settingsObject.physics.debugMode = xml:getBool(manager.XMLTAG..".physics.debugMode", manager.defaultConfig.physics.debugMode)
-                
+
+                -- Load saved event state (temp fields; applied in loadFinished when g_currentMission.time is valid)
+                local savedEvent = xml:getString(manager.XMLTAG..".eventState.activeEvent", "")
+                settingsObject._savedActiveEvent = savedEvent ~= "" and savedEvent or nil
+                settingsObject._savedRemainingMs = xml:getFloat(manager.XMLTAG..".eventState.remainingMs", 0)
+                settingsObject._savedCooldownRemainingMs = xml:getFloat(manager.XMLTAG..".eventState.cooldownRemainingMs", 0)
+                settingsObject._savedMidpointFired = xml:getBool(manager.XMLTAG..".eventState.midpointFired", false)
+
                 xml:delete()
                 return
             end
@@ -271,7 +278,20 @@ function RandomWorldEvents:createSettingsManager()
             xml:setFloat(manager.XMLTAG..".physics.suspensionStiffness", settingsObject.physics.suspensionStiffness)
             xml:setBool(manager.XMLTAG..".physics.showPhysicsInfo", settingsObject.physics.showPhysicsInfo)
             xml:setBool(manager.XMLTAG..".physics.debugMode", settingsObject.physics.debugMode)
-            
+
+            -- Save active event state as remaining time so timers survive reload
+            local es = settingsObject.EVENT_STATE
+            if es and es.activeEvent then
+                xml:setString(manager.XMLTAG..".eventState.activeEvent", es.activeEvent)
+                local remaining = math.max(0, (es.eventStartTime + (es.eventDuration or 0)) - g_currentMission.time)
+                xml:setFloat(manager.XMLTAG..".eventState.remainingMs", remaining)
+                xml:setBool(manager.XMLTAG..".eventState.midpointFired", es.midpointFired or false)
+            else
+                xml:setString(manager.XMLTAG..".eventState.activeEvent", "")
+            end
+            local esCooldown = es and math.max(0, (es.cooldownUntil or 0) - g_currentMission.time) or 0
+            xml:setFloat(manager.XMLTAG..".eventState.cooldownRemainingMs", esCooldown)
+
             xml:save()
             xml:delete()
             self:dbg("Settings saved successfully")
@@ -1108,6 +1128,24 @@ local function loadFinished(mission, ...)
             end
 
             g_inputBinding:endActionEventsModification()
+        end
+
+        -- Restore active event state saved before this session ended.
+        -- g_currentMission.time is valid here; we use remaining-time offsets
+        -- instead of absolute timestamps so reloads work correctly.
+        if g_RandomWorldEvents and g_RandomWorldEvents._savedActiveEvent then
+            local mgr = g_RandomWorldEvents
+            local es = mgr.EVENT_STATE
+            es.activeEvent    = mgr._savedActiveEvent
+            es.eventStartTime = g_currentMission.time
+            es.eventDuration  = mgr._savedRemainingMs or 0
+            es.midpointFired  = mgr._savedMidpointFired or false
+            es.cooldownUntil  = g_currentMission.time + (mgr._savedCooldownRemainingMs or 0)
+            mgr._savedActiveEvent         = nil
+            mgr._savedRemainingMs         = nil
+            mgr._savedCooldownRemainingMs = nil
+            mgr._savedMidpointFired       = nil
+            Logging.info("[RWE] Resumed active event from save: " .. tostring(es.activeEvent))
         end
     end
 end

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
     <version>2.1.6.1</version>
@@ -119,26 +119,71 @@
             <en>Event Timing</en>
             <uk>Розклад подій</uk>
             <da>Interval for hændelser</da>
+        
+            <de>[EN] Event Timing</de>
+            <fr>[EN] Event Timing</fr>
+            <pl>[EN] Event Timing</pl>
+            <es>[EN] Event Timing</es>
+            <it>[EN] Event Timing</it>
+            <cz>[EN] Event Timing</cz>
+            <br>[EN] Event Timing</br>
+            <ru>[EN] Event Timing</ru>
         </text>
         <text name="rwe_subheader_hud">
             <en>Notifications &amp; HUD</en>
             <uk>Сповіщення та HUD</uk>
             <da>Notifikationer &amp; HUD</da>
+        
+            <de>[EN] Notifications &amp; HUD</de>
+            <fr>[EN] Notifications &amp; HUD</fr>
+            <pl>[EN] Notifications &amp; HUD</pl>
+            <es>[EN] Notifications &amp; HUD</es>
+            <it>[EN] Notifications &amp; HUD</it>
+            <cz>[EN] Notifications &amp; HUD</cz>
+            <br>[EN] Notifications &amp; HUD</br>
+            <ru>[EN] Notifications &amp; HUD</ru>
         </text>
         <text name="rwe_subheader_categories">
             <en>Event Categories</en>
             <uk>Категорії подій</uk>
             <da>Hændelsestyper</da>
+        
+            <de>[EN] Event Categories</de>
+            <fr>[EN] Event Categories</fr>
+            <pl>[EN] Event Categories</pl>
+            <es>[EN] Event Categories</es>
+            <it>[EN] Event Categories</it>
+            <cz>[EN] Event Categories</cz>
+            <br>[EN] Event Categories</br>
+            <ru>[EN] Event Categories</ru>
         </text>
         <text name="rwe_subheader_physics">
             <en>Physics Override</en>
             <uk>Налаштування фізики</uk>
             <da>Fysikoverstyring</da>
+        
+            <de>[EN] Physics Override</de>
+            <fr>[EN] Physics Override</fr>
+            <pl>[EN] Physics Override</pl>
+            <es>[EN] Physics Override</es>
+            <it>[EN] Physics Override</it>
+            <cz>[EN] Physics Override</cz>
+            <br>[EN] Physics Override</br>
+            <ru>[EN] Physics Override</ru>
         </text>
         <text name="rwe_subheader_debug">
             <en>Debug</en>
             <uk>Налагодження</uk>
             <da>Fejlfinding</da>
+        
+            <de>[EN] Debug</de>
+            <fr>[EN] Debug</fr>
+            <pl>[EN] Debug</pl>
+            <es>[EN] Debug</es>
+            <it>[EN] Debug</it>
+            <cz>[EN] Debug</cz>
+            <br>[EN] Debug</br>
+            <ru>[EN] Debug</ru>
         </text>
 
         <!-- Timing -->
@@ -146,31 +191,85 @@
             <en>Frequency</en>
             <uk>Частота</uk>
             <da>Frekvens</da>
+        
+            <de>[EN] Frequency</de>
+            <fr>[EN] Frequency</fr>
+            <pl>[EN] Frequency</pl>
+            <es>[EN] Frequency</es>
+            <it>[EN] Frequency</it>
+            <cz>[EN] Frequency</cz>
+            <br>[EN] Frequency</br>
+            <ru>[EN] Frequency</ru>
         </text>
         <text name="rwe_frequency_long">
             <en>How often events fire (1 = rare, 10 = frequent)</en>
             <uk>Як часто виникають події (1 = рідко, 10 = часто)</uk>
             <da>Hvor ofte hændelser udløses (1 = sjældent, 10 = ofte)</da>
+        
+            <de>[EN] How often events fire (1 = rare, 10 = frequent)</de>
+            <fr>[EN] How often events fire (1 = rare, 10 = frequent)</fr>
+            <pl>[EN] How often events fire (1 = rare, 10 = frequent)</pl>
+            <es>[EN] How often events fire (1 = rare, 10 = frequent)</es>
+            <it>[EN] How often events fire (1 = rare, 10 = frequent)</it>
+            <cz>[EN] How often events fire (1 = rare, 10 = frequent)</cz>
+            <br>[EN] How often events fire (1 = rare, 10 = frequent)</br>
+            <ru>[EN] How often events fire (1 = rare, 10 = frequent)</ru>
         </text>
         <text name="rwe_intensity_short">
             <en>Intensity</en>
             <uk>Інтенсивність</uk>
             <da>Styrke</da>
+        
+            <de>[EN] Intensity</de>
+            <fr>[EN] Intensity</fr>
+            <pl>[EN] Intensity</pl>
+            <es>[EN] Intensity</es>
+            <it>[EN] Intensity</it>
+            <cz>[EN] Intensity</cz>
+            <br>[EN] Intensity</br>
+            <ru>[EN] Intensity</ru>
         </text>
         <text name="rwe_intensity_long">
             <en>Strength of event effects (1 = mild, 5 = extreme)</en>
             <uk>Сила ефектів подій (1 = слабка, 5 = екстремальна)</uk>
             <da>Styrken af hændelseseffekter (1 = mild, 5 = ekstrem)</da>
+        
+            <de>[EN] Strength of event effects (1 = mild, 5 = extreme)</de>
+            <fr>[EN] Strength of event effects (1 = mild, 5 = extreme)</fr>
+            <pl>[EN] Strength of event effects (1 = mild, 5 = extreme)</pl>
+            <es>[EN] Strength of event effects (1 = mild, 5 = extreme)</es>
+            <it>[EN] Strength of event effects (1 = mild, 5 = extreme)</it>
+            <cz>[EN] Strength of event effects (1 = mild, 5 = extreme)</cz>
+            <br>[EN] Strength of event effects (1 = mild, 5 = extreme)</br>
+            <ru>[EN] Strength of event effects (1 = mild, 5 = extreme)</ru>
         </text>
         <text name="rwe_cooldown_short">
             <en>Cooldown</en>
             <uk>Перерва</uk>
             <da>Cooldown</da>
+        
+            <de>[EN] Cooldown</de>
+            <fr>[EN] Cooldown</fr>
+            <pl>[EN] Cooldown</pl>
+            <es>[EN] Cooldown</es>
+            <it>[EN] Cooldown</it>
+            <cz>[EN] Cooldown</cz>
+            <br>[EN] Cooldown</br>
+            <ru>[EN] Cooldown</ru>
         </text>
         <text name="rwe_cooldown_long">
             <en>Minimum in-game time between events</en>
             <uk>Мінімальний ігровий час між подіями</uk>
             <da>Minimum in-game tid mellem hændelser</da>
+        
+            <de>[EN] Minimum in-game time between events</de>
+            <fr>[EN] Minimum in-game time between events</fr>
+            <pl>[EN] Minimum in-game time between events</pl>
+            <es>[EN] Minimum in-game time between events</es>
+            <it>[EN] Minimum in-game time between events</it>
+            <cz>[EN] Minimum in-game time between events</cz>
+            <br>[EN] Minimum in-game time between events</br>
+            <ru>[EN] Minimum in-game time between events</ru>
         </text>
 
         <!-- Notifications and HUD -->
@@ -178,41 +277,113 @@
             <en>Show Notifications</en>
             <uk>Показувати сповіщення</uk>
             <da>Vis Notifikationer</da>
+        
+            <de>[EN] Show Notifications</de>
+            <fr>[EN] Show Notifications</fr>
+            <pl>[EN] Show Notifications</pl>
+            <es>[EN] Show Notifications</es>
+            <it>[EN] Show Notifications</it>
+            <cz>[EN] Show Notifications</cz>
+            <br>[EN] Show Notifications</br>
+            <ru>[EN] Show Notifications</ru>
         </text>
         <text name="rwe_notifications_long">
             <en>Display event notifications on screen</en>
             <uk>Відображати сповіщення про події на екрані</uk>
             <da>Vis hændelsesnotifikationer på skærmen</da>
+        
+            <de>[EN] Display event notifications on screen</de>
+            <fr>[EN] Display event notifications on screen</fr>
+            <pl>[EN] Display event notifications on screen</pl>
+            <es>[EN] Display event notifications on screen</es>
+            <it>[EN] Display event notifications on screen</it>
+            <cz>[EN] Display event notifications on screen</cz>
+            <br>[EN] Display event notifications on screen</br>
+            <ru>[EN] Display event notifications on screen</ru>
         </text>
         <text name="rwe_warnings_short">
             <en>Show Warnings</en>
             <uk>Показувати попередження</uk>
             <da>Vis Advarsler</da>
+        
+            <de>[EN] Show Warnings</de>
+            <fr>[EN] Show Warnings</fr>
+            <pl>[EN] Show Warnings</pl>
+            <es>[EN] Show Warnings</es>
+            <it>[EN] Show Warnings</it>
+            <cz>[EN] Show Warnings</cz>
+            <br>[EN] Show Warnings</br>
+            <ru>[EN] Show Warnings</ru>
         </text>
         <text name="rwe_warnings_long">
             <en>Show event warning messages</en>
             <uk>Відображати попереджувальні повідомлення про події</uk>
             <da>Vis hændelsesadvarsler</da>
+        
+            <de>[EN] Show event warning messages</de>
+            <fr>[EN] Show event warning messages</fr>
+            <pl>[EN] Show event warning messages</pl>
+            <es>[EN] Show event warning messages</es>
+            <it>[EN] Show event warning messages</it>
+            <cz>[EN] Show event warning messages</cz>
+            <br>[EN] Show event warning messages</br>
+            <ru>[EN] Show event warning messages</ru>
         </text>
         <text name="rwe_show_hud_short">
             <en>Show HUD Panel</en>
             <uk>Показати панель HUD</uk>
             <da>Vis HUD-panel</da>
+        
+            <de>[EN] Show HUD Panel</de>
+            <fr>[EN] Show HUD Panel</fr>
+            <pl>[EN] Show HUD Panel</pl>
+            <es>[EN] Show HUD Panel</es>
+            <it>[EN] Show HUD Panel</it>
+            <cz>[EN] Show HUD Panel</cz>
+            <br>[EN] Show HUD Panel</br>
+            <ru>[EN] Show HUD Panel</ru>
         </text>
         <text name="rwe_show_hud_long">
             <en>Show the World Events HUD overlay (F3 to toggle in-game)</en>
             <uk>Показати накладку HUD світових подій (F3 для перемикання в грі)</uk>
             <da>Vis HUD-overlayet for hændelser (F3 for at slå til/fra i spillet)</da>
+        
+            <de>[EN] Show the World Events HUD overlay (F3 to toggle in-game)</de>
+            <fr>[EN] Show the World Events HUD overlay (F3 to toggle in-game)</fr>
+            <pl>[EN] Show the World Events HUD overlay (F3 to toggle in-game)</pl>
+            <es>[EN] Show the World Events HUD overlay (F3 to toggle in-game)</es>
+            <it>[EN] Show the World Events HUD overlay (F3 to toggle in-game)</it>
+            <cz>[EN] Show the World Events HUD overlay (F3 to toggle in-game)</cz>
+            <br>[EN] Show the World Events HUD overlay (F3 to toggle in-game)</br>
+            <ru>[EN] Show the World Events HUD overlay (F3 to toggle in-game)</ru>
         </text>
         <text name="rwe_hud_scale_short">
             <en>HUD Scale</en>
             <uk>Масштаб HUD</uk>
             <da>HUD-skala</da>
+        
+            <de>[EN] HUD Scale</de>
+            <fr>[EN] HUD Scale</fr>
+            <pl>[EN] HUD Scale</pl>
+            <es>[EN] HUD Scale</es>
+            <it>[EN] HUD Scale</it>
+            <cz>[EN] HUD Scale</cz>
+            <br>[EN] HUD Scale</br>
+            <ru>[EN] HUD Scale</ru>
         </text>
         <text name="rwe_hud_scale_long">
             <en>Size of the World Events HUD panel</en>
             <uk>Розмір панелі HUD світових подій</uk>
             <da>Størrelse på HUD-panelet for hændelser</da>
+        
+            <de>[EN] Size of the World Events HUD panel</de>
+            <fr>[EN] Size of the World Events HUD panel</fr>
+            <pl>[EN] Size of the World Events HUD panel</pl>
+            <es>[EN] Size of the World Events HUD panel</es>
+            <it>[EN] Size of the World Events HUD panel</it>
+            <cz>[EN] Size of the World Events HUD panel</cz>
+            <br>[EN] Size of the World Events HUD panel</br>
+            <ru>[EN] Size of the World Events HUD panel</ru>
         </text>
 
         <!-- Categories -->
@@ -220,51 +391,141 @@
             <en>Economic Events</en>
             <uk>Економічні події</uk>
             <da>Økonomiske hændelser</da>
+        
+            <de>[EN] Economic Events</de>
+            <fr>[EN] Economic Events</fr>
+            <pl>[EN] Economic Events</pl>
+            <es>[EN] Economic Events</es>
+            <it>[EN] Economic Events</it>
+            <cz>[EN] Economic Events</cz>
+            <br>[EN] Economic Events</br>
+            <ru>[EN] Economic Events</ru>
         </text>
         <text name="rwe_economic_long">
             <en>Enable market and economic events</en>
             <uk>Увімкнути ринкові та економічні події</uk>
             <da>Slå markeds- og økonomiske hændelser til</da>
+        
+            <de>[EN] Enable market and economic events</de>
+            <fr>[EN] Enable market and economic events</fr>
+            <pl>[EN] Enable market and economic events</pl>
+            <es>[EN] Enable market and economic events</es>
+            <it>[EN] Enable market and economic events</it>
+            <cz>[EN] Enable market and economic events</cz>
+            <br>[EN] Enable market and economic events</br>
+            <ru>[EN] Enable market and economic events</ru>
         </text>
         <text name="rwe_vehicle_short">
             <en>Vehicle Events</en>
             <uk>Події з технікою</uk>
             <da>Køretøjshændelser</da>
+        
+            <de>[EN] Vehicle Events</de>
+            <fr>[EN] Vehicle Events</fr>
+            <pl>[EN] Vehicle Events</pl>
+            <es>[EN] Vehicle Events</es>
+            <it>[EN] Vehicle Events</it>
+            <cz>[EN] Vehicle Events</cz>
+            <br>[EN] Vehicle Events</br>
+            <ru>[EN] Vehicle Events</ru>
         </text>
         <text name="rwe_vehicle_long">
             <en>Enable vehicle events (speed, fuel, damage)</en>
             <uk>Увімкнути події з технікою (швидкість, паливо, пошкодження)</uk>
             <da>Aktivér køretøjshændelser (hastighed, brændstof, skader)</da>
+        
+            <de>[EN] Enable vehicle events (speed, fuel, damage)</de>
+            <fr>[EN] Enable vehicle events (speed, fuel, damage)</fr>
+            <pl>[EN] Enable vehicle events (speed, fuel, damage)</pl>
+            <es>[EN] Enable vehicle events (speed, fuel, damage)</es>
+            <it>[EN] Enable vehicle events (speed, fuel, damage)</it>
+            <cz>[EN] Enable vehicle events (speed, fuel, damage)</cz>
+            <br>[EN] Enable vehicle events (speed, fuel, damage)</br>
+            <ru>[EN] Enable vehicle events (speed, fuel, damage)</ru>
         </text>
         <text name="rwe_field_short">
             <en>Field Events</en>
             <uk>Події на полях</uk>
             <da>Markhændelser</da>
+        
+            <de>[EN] Field Events</de>
+            <fr>[EN] Field Events</fr>
+            <pl>[EN] Field Events</pl>
+            <es>[EN] Field Events</es>
+            <it>[EN] Field Events</it>
+            <cz>[EN] Field Events</cz>
+            <br>[EN] Field Events</br>
+            <ru>[EN] Field Events</ru>
         </text>
         <text name="rwe_field_long">
             <en>Enable crop and field events</en>
             <uk>Увімкнути події з культурами та полями</uk>
             <da>Aktivér afgrøde- og markhændelser</da>
+        
+            <de>[EN] Enable crop and field events</de>
+            <fr>[EN] Enable crop and field events</fr>
+            <pl>[EN] Enable crop and field events</pl>
+            <es>[EN] Enable crop and field events</es>
+            <it>[EN] Enable crop and field events</it>
+            <cz>[EN] Enable crop and field events</cz>
+            <br>[EN] Enable crop and field events</br>
+            <ru>[EN] Enable crop and field events</ru>
         </text>
         <text name="rwe_wildlife_short">
             <en>Wildlife Events</en>
             <uk>Події з дикою природою</uk>
             <da>Dyrelivshændelser</da>
+        
+            <de>[EN] Wildlife Events</de>
+            <fr>[EN] Wildlife Events</fr>
+            <pl>[EN] Wildlife Events</pl>
+            <es>[EN] Wildlife Events</es>
+            <it>[EN] Wildlife Events</it>
+            <cz>[EN] Wildlife Events</cz>
+            <br>[EN] Wildlife Events</br>
+            <ru>[EN] Wildlife Events</ru>
         </text>
         <text name="rwe_wildlife_long">
             <en>Enable wildlife and animal events</en>
             <uk>Увімкнути події з дикою природою та тваринами</uk>
             <da>Aktivér hændelser med dyreliv og dyr</da>
+        
+            <de>[EN] Enable wildlife and animal events</de>
+            <fr>[EN] Enable wildlife and animal events</fr>
+            <pl>[EN] Enable wildlife and animal events</pl>
+            <es>[EN] Enable wildlife and animal events</es>
+            <it>[EN] Enable wildlife and animal events</it>
+            <cz>[EN] Enable wildlife and animal events</cz>
+            <br>[EN] Enable wildlife and animal events</br>
+            <ru>[EN] Enable wildlife and animal events</ru>
         </text>
         <text name="rwe_special_short">
             <en>Special Events</en>
             <uk>Особливі події</uk>
             <da>Særlige hændelser</da>
+        
+            <de>[EN] Special Events</de>
+            <fr>[EN] Special Events</fr>
+            <pl>[EN] Special Events</pl>
+            <es>[EN] Special Events</es>
+            <it>[EN] Special Events</it>
+            <cz>[EN] Special Events</cz>
+            <br>[EN] Special Events</br>
+            <ru>[EN] Special Events</ru>
         </text>
         <text name="rwe_special_long">
             <en>Enable time, XP, and special events</en>
             <uk>Увімкнути події з часом, досвідом та особливі події</uk>
             <da>Aktivér tids-, XP- og Særlige hændelser</da>
+        
+            <de>[EN] Enable time, XP, and special events</de>
+            <fr>[EN] Enable time, XP, and special events</fr>
+            <pl>[EN] Enable time, XP, and special events</pl>
+            <es>[EN] Enable time, XP, and special events</es>
+            <it>[EN] Enable time, XP, and special events</it>
+            <cz>[EN] Enable time, XP, and special events</cz>
+            <br>[EN] Enable time, XP, and special events</br>
+            <ru>[EN] Enable time, XP, and special events</ru>
         </text>
 
         <!-- Physics -->
@@ -272,31 +533,85 @@
             <en>Enable Physics Override</en>
             <uk>Увімкнути налаштування фізики</uk>
             <da>Aktivér fysikoverstyring</da>
+        
+            <de>[EN] Enable Physics Override</de>
+            <fr>[EN] Enable Physics Override</fr>
+            <pl>[EN] Enable Physics Override</pl>
+            <es>[EN] Enable Physics Override</es>
+            <it>[EN] Enable Physics Override</it>
+            <cz>[EN] Enable Physics Override</cz>
+            <br>[EN] Enable Physics Override</br>
+            <ru>[EN] Enable Physics Override</ru>
         </text>
         <text name="rwe_physics_enabled_long">
             <en>Apply terrain-aware wheel grip and suspension</en>
             <uk>Застосувати зчеплення коліс і підвіску залежно від типу поверхні</uk>
             <da>Anvend terræntilpasset hjulgreb og affjedring</da>
+        
+            <de>[EN] Apply terrain-aware wheel grip and suspension</de>
+            <fr>[EN] Apply terrain-aware wheel grip and suspension</fr>
+            <pl>[EN] Apply terrain-aware wheel grip and suspension</pl>
+            <es>[EN] Apply terrain-aware wheel grip and suspension</es>
+            <it>[EN] Apply terrain-aware wheel grip and suspension</it>
+            <cz>[EN] Apply terrain-aware wheel grip and suspension</cz>
+            <br>[EN] Apply terrain-aware wheel grip and suspension</br>
+            <ru>[EN] Apply terrain-aware wheel grip and suspension</ru>
         </text>
         <text name="rwe_wheel_grip_short">
             <en>Wheel Grip</en>
             <uk>Зчеплення коліс</uk>
             <da>hjulgreb</da>
+        
+            <de>[EN] Wheel Grip</de>
+            <fr>[EN] Wheel Grip</fr>
+            <pl>[EN] Wheel Grip</pl>
+            <es>[EN] Wheel Grip</es>
+            <it>[EN] Wheel Grip</it>
+            <cz>[EN] Wheel Grip</cz>
+            <br>[EN] Wheel Grip</br>
+            <ru>[EN] Wheel Grip</ru>
         </text>
         <text name="rwe_wheel_grip_long">
             <en>Scale terrain grip values (1.00 = default)</en>
             <uk>Масштаб зчеплення з поверхнею (1.00 = за замовчуванням)</uk>
             <da>Skaler terrænets grebsværdier (1,00 = standard)</da>
+        
+            <de>[EN] Scale terrain grip values (1.00 = default)</de>
+            <fr>[EN] Scale terrain grip values (1.00 = default)</fr>
+            <pl>[EN] Scale terrain grip values (1.00 = default)</pl>
+            <es>[EN] Scale terrain grip values (1.00 = default)</es>
+            <it>[EN] Scale terrain grip values (1.00 = default)</it>
+            <cz>[EN] Scale terrain grip values (1.00 = default)</cz>
+            <br>[EN] Scale terrain grip values (1.00 = default)</br>
+            <ru>[EN] Scale terrain grip values (1.00 = default)</ru>
         </text>
         <text name="rwe_suspension_short">
             <en>Suspension Stiffness</en>
             <uk>Жорсткість підвіски</uk>
             <da>Affjedringsstivhed</da>
+        
+            <de>[EN] Suspension Stiffness</de>
+            <fr>[EN] Suspension Stiffness</fr>
+            <pl>[EN] Suspension Stiffness</pl>
+            <es>[EN] Suspension Stiffness</es>
+            <it>[EN] Suspension Stiffness</it>
+            <cz>[EN] Suspension Stiffness</cz>
+            <br>[EN] Suspension Stiffness</br>
+            <ru>[EN] Suspension Stiffness</ru>
         </text>
         <text name="rwe_suspension_long">
             <en>Scale suspension spring force (1.00 = default)</en>
             <uk>Масштаб сили пружини підвіски (1.00 = за замовчуванням)</uk>
             <da>Skaler affjedringens fjederkraft (1,00 = standard)</da>
+        
+            <de>[EN] Scale suspension spring force (1.00 = default)</de>
+            <fr>[EN] Scale suspension spring force (1.00 = default)</fr>
+            <pl>[EN] Scale suspension spring force (1.00 = default)</pl>
+            <es>[EN] Scale suspension spring force (1.00 = default)</es>
+            <it>[EN] Scale suspension spring force (1.00 = default)</it>
+            <cz>[EN] Scale suspension spring force (1.00 = default)</cz>
+            <br>[EN] Scale suspension spring force (1.00 = default)</br>
+            <ru>[EN] Scale suspension spring force (1.00 = default)</ru>
         </text>
 
         <!-- Debug -->
@@ -304,21 +619,57 @@
             <en>Show Physics Info</en>
             <uk>Показати інформацію про фізику</uk>
             <da>Vis fysikinfo</da>
+        
+            <de>[EN] Show Physics Info</de>
+            <fr>[EN] Show Physics Info</fr>
+            <pl>[EN] Show Physics Info</pl>
+            <es>[EN] Show Physics Info</es>
+            <it>[EN] Show Physics Info</it>
+            <cz>[EN] Show Physics Info</cz>
+            <br>[EN] Show Physics Info</br>
+            <ru>[EN] Show Physics Info</ru>
         </text>
         <text name="rwe_physics_info_long">
             <en>Log per-vehicle speed and grip data each frame</en>
             <uk>Записувати дані швидкості та зчеплення для кожного транспортного засобу щокадру</uk>
             <da>Log hastigheds- og grebsdata pr. køretøj i hver frame</da>
+        
+            <de>[EN] Log per-vehicle speed and grip data each frame</de>
+            <fr>[EN] Log per-vehicle speed and grip data each frame</fr>
+            <pl>[EN] Log per-vehicle speed and grip data each frame</pl>
+            <es>[EN] Log per-vehicle speed and grip data each frame</es>
+            <it>[EN] Log per-vehicle speed and grip data each frame</it>
+            <cz>[EN] Log per-vehicle speed and grip data each frame</cz>
+            <br>[EN] Log per-vehicle speed and grip data each frame</br>
+            <ru>[EN] Log per-vehicle speed and grip data each frame</ru>
         </text>
         <text name="rwe_debug_short">
             <en>Debug Mode</en>
             <uk>Режим налагодження</uk>
             <da>Fejlfindingstilstand</da>
+        
+            <de>[EN] Debug Mode</de>
+            <fr>[EN] Debug Mode</fr>
+            <pl>[EN] Debug Mode</pl>
+            <es>[EN] Debug Mode</es>
+            <it>[EN] Debug Mode</it>
+            <cz>[EN] Debug Mode</cz>
+            <br>[EN] Debug Mode</br>
+            <ru>[EN] Debug Mode</ru>
         </text>
         <text name="rwe_debug_long">
             <en>Show verbose Random World Events debug output</en>
             <uk>Показувати детальні діагностичні дані випадкових світових подій</uk>
             <da>Vis detaljeret debugoutput for tilfældige hændelser</da>
+        
+            <de>[EN] Show verbose Random World Events debug output</de>
+            <fr>[EN] Show verbose Random World Events debug output</fr>
+            <pl>[EN] Show verbose Random World Events debug output</pl>
+            <es>[EN] Show verbose Random World Events debug output</es>
+            <it>[EN] Show verbose Random World Events debug output</it>
+            <cz>[EN] Show verbose Random World Events debug output</cz>
+            <br>[EN] Show verbose Random World Events debug output</br>
+            <ru>[EN] Show verbose Random World Events debug output</ru>
         </text>
 
         <!-- Input action description (shows in keybinding menu) -->
@@ -326,6 +677,15 @@
             <en>Toggle Random World Events HUD</en>
             <uk>Перемкнути HUD випадкових світових подій</uk>
             <da>Skift tilfældige hændelser HUD</da>
+        
+            <de>[EN] Toggle Random World Events HUD</de>
+            <fr>[EN] Toggle Random World Events HUD</fr>
+            <pl>[EN] Toggle Random World Events HUD</pl>
+            <es>[EN] Toggle Random World Events HUD</es>
+            <it>[EN] Toggle Random World Events HUD</it>
+            <cz>[EN] Toggle Random World Events HUD</cz>
+            <br>[EN] Toggle Random World Events HUD</br>
+            <ru>[EN] Toggle Random World Events HUD</ru>
         </text>
         <text name="input_RWE_TOGGLE_SETTINGS">
             <en>Toggle Random World Events Settings</en>
@@ -346,21 +706,57 @@
             <en>Overview</en>
             <uk>Огляд</uk>
             <da>Oversigt</da>
+        
+            <de>[EN] Overview</de>
+            <fr>[EN] Overview</fr>
+            <pl>[EN] Overview</pl>
+            <es>[EN] Overview</es>
+            <it>[EN] Overview</it>
+            <cz>[EN] Overview</cz>
+            <br>[EN] Overview</br>
+            <ru>[EN] Overview</ru>
         </text>
         <text name="helpLine_rwe_cat_categories">
             <en>Event Categories</en>
             <uk>Категорії подій</uk>
             <da>Hændelseskategorier</da>
+        
+            <de>[EN] Event Categories</de>
+            <fr>[EN] Event Categories</fr>
+            <pl>[EN] Event Categories</pl>
+            <es>[EN] Event Categories</es>
+            <it>[EN] Event Categories</it>
+            <cz>[EN] Event Categories</cz>
+            <br>[EN] Event Categories</br>
+            <ru>[EN] Event Categories</ru>
         </text>
         <text name="helpLine_rwe_cat_settings">
             <en>Settings</en>
             <uk>Налаштування</uk>
             <da>indstillinger</da>
+        
+            <de>[EN] Settings</de>
+            <fr>[EN] Settings</fr>
+            <pl>[EN] Settings</pl>
+            <es>[EN] Settings</es>
+            <it>[EN] Settings</it>
+            <cz>[EN] Settings</cz>
+            <br>[EN] Settings</br>
+            <ru>[EN] Settings</ru>
         </text>
         <text name="helpLine_rwe_cat_controls">
             <en>Controls &amp; Commands</en>
             <uk>Керування та команди</uk>
             <da>Styring &amp; kommandoer</da>
+        
+            <de>[EN] Controls &amp; Commands</de>
+            <fr>[EN] Controls &amp; Commands</fr>
+            <pl>[EN] Controls &amp; Commands</pl>
+            <es>[EN] Controls &amp; Commands</es>
+            <it>[EN] Controls &amp; Commands</it>
+            <cz>[EN] Controls &amp; Commands</cz>
+            <br>[EN] Controls &amp; Commands</br>
+            <ru>[EN] Controls &amp; Commands</ru>
         </text>
 
         <!-- Help page: Overview page 1 -->
@@ -368,26 +764,71 @@
             <en>What is Random World Events?</en>
             <uk>Що таке випадкові світові події?</uk>
             <da> Hvad er Random World Events</da>
+        
+            <de>[EN] What is Random World Events?</de>
+            <fr>[EN] What is Random World Events?</fr>
+            <pl>[EN] What is Random World Events?</pl>
+            <es>[EN] What is Random World Events?</es>
+            <it>[EN] What is Random World Events?</it>
+            <cz>[EN] What is Random World Events?</cz>
+            <br>[EN] What is Random World Events?</br>
+            <ru>[EN] What is Random World Events?</ru>
         </text>
         <text name="helpLine_rwe_ov1_intro_title">
             <en>Living World</en>
             <uk>Живий світ</uk>
             <da>Levende verden</da>
+        
+            <de>[EN] Living World</de>
+            <fr>[EN] Living World</fr>
+            <pl>[EN] Living World</pl>
+            <es>[EN] Living World</es>
+            <it>[EN] Living World</it>
+            <cz>[EN] Living World</cz>
+            <br>[EN] Living World</br>
+            <ru>[EN] Living World</ru>
         </text>
         <text name="helpLine_rwe_ov1_intro_text">
             <en>Random World Events brings dynamic, unpredictable events to your farm. 53 unique events across five categories fire automatically during play, affecting your economy, vehicles, fields, wildlife, and more. No two playthroughs will feel the same.</en>
             <uk>Випадкові світові події привносять динамічні та непередбачувані події на вашу ферму. 53 унікальні події у п'яти категоріях запускаються автоматично під час гри, впливаючи на економіку, техніку, поля, дику природу та багато іншого. Жодне проходження не буде схожим на попереднє.</uk>
             <da>Random World Events bringer dynamiske og uforudsigelige hændelser til din gård. 53 unikke hændelser fordelt på fem kategorier udløses automatisk under spillet og påvirker din økonomi, dine køretøjer, marker, dyreliv og meget mere. Hver gennemspilning føles unik.</da>
+        
+            <de>[EN] Random World Events brings dynamic, unpredictable events to your farm. 53 unique events across five categories fire automatically during play, affecting your economy, vehicles, fields, wildlife, and more. No two playthroughs will feel the same.</de>
+            <fr>[EN] Random World Events brings dynamic, unpredictable events to your farm. 53 unique events across five categories fire automatically during play, affecting your economy, vehicles, fields, wildlife, and more. No two playthroughs will feel the same.</fr>
+            <pl>[EN] Random World Events brings dynamic, unpredictable events to your farm. 53 unique events across five categories fire automatically during play, affecting your economy, vehicles, fields, wildlife, and more. No two playthroughs will feel the same.</pl>
+            <es>[EN] Random World Events brings dynamic, unpredictable events to your farm. 53 unique events across five categories fire automatically during play, affecting your economy, vehicles, fields, wildlife, and more. No two playthroughs will feel the same.</es>
+            <it>[EN] Random World Events brings dynamic, unpredictable events to your farm. 53 unique events across five categories fire automatically during play, affecting your economy, vehicles, fields, wildlife, and more. No two playthroughs will feel the same.</it>
+            <cz>[EN] Random World Events brings dynamic, unpredictable events to your farm. 53 unique events across five categories fire automatically during play, affecting your economy, vehicles, fields, wildlife, and more. No two playthroughs will feel the same.</cz>
+            <br>[EN] Random World Events brings dynamic, unpredictable events to your farm. 53 unique events across five categories fire automatically during play, affecting your economy, vehicles, fields, wildlife, and more. No two playthroughs will feel the same.</br>
+            <ru>[EN] Random World Events brings dynamic, unpredictable events to your farm. 53 unique events across five categories fire automatically during play, affecting your economy, vehicles, fields, wildlife, and more. No two playthroughs will feel the same.</ru>
         </text>
         <text name="helpLine_rwe_ov1_expect_title">
             <en>What to Expect</en>
             <uk>Чого очікувати</uk>
             <da>Hvad kan du forvente</da>
+        
+            <de>[EN] What to Expect</de>
+            <fr>[EN] What to Expect</fr>
+            <pl>[EN] What to Expect</pl>
+            <es>[EN] What to Expect</es>
+            <it>[EN] What to Expect</it>
+            <cz>[EN] What to Expect</cz>
+            <br>[EN] What to Expect</br>
+            <ru>[EN] What to Expect</ru>
         </text>
         <text name="helpLine_rwe_ov1_expect_text">
             <en>Events appear as HUD notifications and last for a configurable duration. Some grant bonuses (market booms, fuel refills, crop buffs), while others impose challenges (accidents, price crashes, stampedes). A cooldown timer prevents event spam.</en>
             <uk>Події відображаються як сповіщення HUD і тривають налаштовуваний час. Деякі дають бонуси (підйоми на ринку, поповнення палива, підсилення врожаю), тоді як інші створюють труднощі (аварії, падіння цін, натовпи тварин). Таймер перерви запобігає надмірній кількості подій.</uk>
             <da>Hændelser vises som HUD-notifikationer og varer i et tidsrum, du selv kan konfigurere. Nogle giver bonusser (markedsboom, brændstofpåfyldning, afgrødebonusser), mens andre skaber udfordringer (ulykker, prisstyrt, paniske dyreflokke). En cooldown-timer sikrer, at hændelser ikke spammer spillet.</da>
+        
+            <de>[EN] Events appear as HUD notifications and last for a configurable duration. Some grant bonuses (market booms, fuel refills, crop buffs), while others impose challenges (accidents, price crashes, stampedes). A cooldown timer prevents event spam.</de>
+            <fr>[EN] Events appear as HUD notifications and last for a configurable duration. Some grant bonuses (market booms, fuel refills, crop buffs), while others impose challenges (accidents, price crashes, stampedes). A cooldown timer prevents event spam.</fr>
+            <pl>[EN] Events appear as HUD notifications and last for a configurable duration. Some grant bonuses (market booms, fuel refills, crop buffs), while others impose challenges (accidents, price crashes, stampedes). A cooldown timer prevents event spam.</pl>
+            <es>[EN] Events appear as HUD notifications and last for a configurable duration. Some grant bonuses (market booms, fuel refills, crop buffs), while others impose challenges (accidents, price crashes, stampedes). A cooldown timer prevents event spam.</es>
+            <it>[EN] Events appear as HUD notifications and last for a configurable duration. Some grant bonuses (market booms, fuel refills, crop buffs), while others impose challenges (accidents, price crashes, stampedes). A cooldown timer prevents event spam.</it>
+            <cz>[EN] Events appear as HUD notifications and last for a configurable duration. Some grant bonuses (market booms, fuel refills, crop buffs), while others impose challenges (accidents, price crashes, stampedes). A cooldown timer prevents event spam.</cz>
+            <br>[EN] Events appear as HUD notifications and last for a configurable duration. Some grant bonuses (market booms, fuel refills, crop buffs), while others impose challenges (accidents, price crashes, stampedes). A cooldown timer prevents event spam.</br>
+            <ru>[EN] Events appear as HUD notifications and last for a configurable duration. Some grant bonuses (market booms, fuel refills, crop buffs), while others impose challenges (accidents, price crashes, stampedes). A cooldown timer prevents event spam.</ru>
         </text>
 
         <!-- Help page: Overview page 2 -->
@@ -395,26 +836,71 @@
             <en>How Events Work</en>
             <uk>Як працюють події</uk>
             <da>Hvordan hændelser virker</da>
+        
+            <de>[EN] How Events Work</de>
+            <fr>[EN] How Events Work</fr>
+            <pl>[EN] How Events Work</pl>
+            <es>[EN] How Events Work</es>
+            <it>[EN] How Events Work</it>
+            <cz>[EN] How Events Work</cz>
+            <br>[EN] How Events Work</br>
+            <ru>[EN] How Events Work</ru>
         </text>
         <text name="helpLine_rwe_ov2_trigger_title">
             <en>Trigger System</en>
             <uk>Система запуску</uk>
             <da>Hændelsesudløser</da>
+        
+            <de>[EN] Trigger System</de>
+            <fr>[EN] Trigger System</fr>
+            <pl>[EN] Trigger System</pl>
+            <es>[EN] Trigger System</es>
+            <it>[EN] Trigger System</it>
+            <cz>[EN] Trigger System</cz>
+            <br>[EN] Trigger System</br>
+            <ru>[EN] Trigger System</ru>
         </text>
         <text name="helpLine_rwe_ov2_trigger_text">
             <en>Each game tick there is a small probability of an event firing, controlled by the Frequency setting (1-10). When an event triggers, a random eligible event from all enabled categories is selected. Only one event can be active at a time.</en>
             <uk>При кожному ігровому тику є невелика ймовірність запуску події, яка контролюється параметром «Частота» (1–10). Коли подія запускається, з усіх увімкнених категорій вибирається випадкова відповідна подія. Одночасно може бути активна лише одна подія.</uk>
             <da>Ved hvert game-tick er der en lille sandsynlighed for, at en hændelse udløses, styret af indstillingen Hyppighed (1–10). Når en hændelse aktiveres, vælges en tilfældig tilgængelig hændelse fra alle aktiverede kategorier. Kun én hændelse kan være aktiv ad gangen.</da>
+        
+            <de>[EN] Each game tick there is a small probability of an event firing, controlled by the Frequency setting (1-10). When an event triggers, a random eligible event from all enabled categories is selected. Only one event can be active at a time.</de>
+            <fr>[EN] Each game tick there is a small probability of an event firing, controlled by the Frequency setting (1-10). When an event triggers, a random eligible event from all enabled categories is selected. Only one event can be active at a time.</fr>
+            <pl>[EN] Each game tick there is a small probability of an event firing, controlled by the Frequency setting (1-10). When an event triggers, a random eligible event from all enabled categories is selected. Only one event can be active at a time.</pl>
+            <es>[EN] Each game tick there is a small probability of an event firing, controlled by the Frequency setting (1-10). When an event triggers, a random eligible event from all enabled categories is selected. Only one event can be active at a time.</es>
+            <it>[EN] Each game tick there is a small probability of an event firing, controlled by the Frequency setting (1-10). When an event triggers, a random eligible event from all enabled categories is selected. Only one event can be active at a time.</it>
+            <cz>[EN] Each game tick there is a small probability of an event firing, controlled by the Frequency setting (1-10). When an event triggers, a random eligible event from all enabled categories is selected. Only one event can be active at a time.</cz>
+            <br>[EN] Each game tick there is a small probability of an event firing, controlled by the Frequency setting (1-10). When an event triggers, a random eligible event from all enabled categories is selected. Only one event can be active at a time.</br>
+            <ru>[EN] Each game tick there is a small probability of an event firing, controlled by the Frequency setting (1-10). When an event triggers, a random eligible event from all enabled categories is selected. Only one event can be active at a time.</ru>
         </text>
         <text name="helpLine_rwe_ov2_intensity_title">
             <en>Intensity &amp; Cooldown</en>
             <uk>Інтенсивність та перерва</uk>
             <da>Intensitet &amp; cooldown</da>
+        
+            <de>[EN] Intensity &amp; Cooldown</de>
+            <fr>[EN] Intensity &amp; Cooldown</fr>
+            <pl>[EN] Intensity &amp; Cooldown</pl>
+            <es>[EN] Intensity &amp; Cooldown</es>
+            <it>[EN] Intensity &amp; Cooldown</it>
+            <cz>[EN] Intensity &amp; Cooldown</cz>
+            <br>[EN] Intensity &amp; Cooldown</br>
+            <ru>[EN] Intensity &amp; Cooldown</ru>
         </text>
         <text name="helpLine_rwe_ov2_intensity_text">
             <en>Intensity (1-5) scales the strength of effects — a level 5 market boom gives a bigger bonus than level 1. After each event, a cooldown period (1-240 minutes) must pass before the next event can fire. Both settings are configurable per savegame.</en>
             <uk>Інтенсивність (1–5) визначає силу ефектів — підйом ринку рівня 5 дає більший бонус, ніж рівень 1. Після кожної події має пройти час перерви (1–240 хвилин), перш ніж може статися наступна подія. Обидва параметри налаштовуються для кожного збереження.</uk>
             <da>Intensitet (1–5) skalerer styrken af effekterne — et markedsboom på niveau 5 giver en større bonus end niveau 1. Efter hver hændelse skal en cooldown-periode (1–240 minutter) passere, før den næste hændelse kan udløses. Begge indstillinger kan konfigureres separat for hvert savegame.</da>
+        
+            <de>[EN] Intensity (1-5) scales the strength of effects — a level 5 market boom gives a bigger bonus than level 1. After each event, a cooldown period (1-240 minutes) must pass before the next event can fire. Both settings are configurable per savegame.</de>
+            <fr>[EN] Intensity (1-5) scales the strength of effects — a level 5 market boom gives a bigger bonus than level 1. After each event, a cooldown period (1-240 minutes) must pass before the next event can fire. Both settings are configurable per savegame.</fr>
+            <pl>[EN] Intensity (1-5) scales the strength of effects — a level 5 market boom gives a bigger bonus than level 1. After each event, a cooldown period (1-240 minutes) must pass before the next event can fire. Both settings are configurable per savegame.</pl>
+            <es>[EN] Intensity (1-5) scales the strength of effects — a level 5 market boom gives a bigger bonus than level 1. After each event, a cooldown period (1-240 minutes) must pass before the next event can fire. Both settings are configurable per savegame.</es>
+            <it>[EN] Intensity (1-5) scales the strength of effects — a level 5 market boom gives a bigger bonus than level 1. After each event, a cooldown period (1-240 minutes) must pass before the next event can fire. Both settings are configurable per savegame.</it>
+            <cz>[EN] Intensity (1-5) scales the strength of effects — a level 5 market boom gives a bigger bonus than level 1. After each event, a cooldown period (1-240 minutes) must pass before the next event can fire. Both settings are configurable per savegame.</cz>
+            <br>[EN] Intensity (1-5) scales the strength of effects — a level 5 market boom gives a bigger bonus than level 1. After each event, a cooldown period (1-240 minutes) must pass before the next event can fire. Both settings are configurable per savegame.</br>
+            <ru>[EN] Intensity (1-5) scales the strength of effects — a level 5 market boom gives a bigger bonus than level 1. After each event, a cooldown period (1-240 minutes) must pass before the next event can fire. Both settings are configurable per savegame.</ru>
         </text>
 
         <!-- Help page: Categories / economic -->
@@ -422,26 +908,71 @@
             <en>Economic Events</en>
             <uk>Економічні події</uk>
             <da>Økonomiske hændelser</da>
+        
+            <de>[EN] Economic Events</de>
+            <fr>[EN] Economic Events</fr>
+            <pl>[EN] Economic Events</pl>
+            <es>[EN] Economic Events</es>
+            <it>[EN] Economic Events</it>
+            <cz>[EN] Economic Events</cz>
+            <br>[EN] Economic Events</br>
+            <ru>[EN] Economic Events</ru>
         </text>
         <text name="helpLine_rwe_cat1_good_title">
             <en>Positive Events (11)</en>
             <uk>Позитивні події (11)</uk>
             <da>Positive hændelser (11)</da>
+        
+            <de>[EN] Positive Events (11)</de>
+            <fr>[EN] Positive Events (11)</fr>
+            <pl>[EN] Positive Events (11)</pl>
+            <es>[EN] Positive Events (11)</es>
+            <it>[EN] Positive Events (11)</it>
+            <cz>[EN] Positive Events (11)</cz>
+            <br>[EN] Positive Events (11)</br>
+            <ru>[EN] Positive Events (11)</ru>
         </text>
         <text name="helpLine_rwe_cat1_good_text">
             <en>Government subsidies, market booms, farmer donations, tax refunds, insurance payouts, export opportunities, seed discounts, fertilizer discounts, fuel discounts, equipment discounts, and price-fixing bonuses (temporary elevated sell prices). These events grant direct cash or temporary price bonuses.</en>
             <uk>Державні субсидії, підйоми на ринку, пожертви фермерів, повернення податків, страхові виплати, експортні можливості, знижки на насіння, знижки на добрива, знижки на паливо, знижки на обладнання та цінові бонуси (тимчасово підвищені ціни продажу). Ці події надають пряму готівку або тимчасові цінові бонуси.</uk>
             <da>Statslige tilskud, markedsboom, donationer fra landmænd, skatterefusioner, forsikringsudbetalinger, eksportmuligheder, rabatter på frø, rabatter på gødning, rabatter på brændstof, rabatter på udstyr samt bonusser fra prisfastsættelse (midlertidigt forhøjede salgspriser). Disse hændelser giver direkte kontanter eller midlertidige prisbonusser.</da>
+        
+            <de>[EN] Government subsidies, market booms, farmer donations, tax refunds, insurance payouts, export opportunities, seed discounts, fertilizer discounts, fuel discounts, equipment discounts, and price-fixing bonuses (temporary elevated sell prices). These events grant direct cash or temporary price bonuses.</de>
+            <fr>[EN] Government subsidies, market booms, farmer donations, tax refunds, insurance payouts, export opportunities, seed discounts, fertilizer discounts, fuel discounts, equipment discounts, and price-fixing bonuses (temporary elevated sell prices). These events grant direct cash or temporary price bonuses.</fr>
+            <pl>[EN] Government subsidies, market booms, farmer donations, tax refunds, insurance payouts, export opportunities, seed discounts, fertilizer discounts, fuel discounts, equipment discounts, and price-fixing bonuses (temporary elevated sell prices). These events grant direct cash or temporary price bonuses.</pl>
+            <es>[EN] Government subsidies, market booms, farmer donations, tax refunds, insurance payouts, export opportunities, seed discounts, fertilizer discounts, fuel discounts, equipment discounts, and price-fixing bonuses (temporary elevated sell prices). These events grant direct cash or temporary price bonuses.</es>
+            <it>[EN] Government subsidies, market booms, farmer donations, tax refunds, insurance payouts, export opportunities, seed discounts, fertilizer discounts, fuel discounts, equipment discounts, and price-fixing bonuses (temporary elevated sell prices). These events grant direct cash or temporary price bonuses.</it>
+            <cz>[EN] Government subsidies, market booms, farmer donations, tax refunds, insurance payouts, export opportunities, seed discounts, fertilizer discounts, fuel discounts, equipment discounts, and price-fixing bonuses (temporary elevated sell prices). These events grant direct cash or temporary price bonuses.</cz>
+            <br>[EN] Government subsidies, market booms, farmer donations, tax refunds, insurance payouts, export opportunities, seed discounts, fertilizer discounts, fuel discounts, equipment discounts, and price-fixing bonuses (temporary elevated sell prices). These events grant direct cash or temporary price bonuses.</br>
+            <ru>[EN] Government subsidies, market booms, farmer donations, tax refunds, insurance payouts, export opportunities, seed discounts, fertilizer discounts, fuel discounts, equipment discounts, and price-fixing bonuses (temporary elevated sell prices). These events grant direct cash or temporary price bonuses.</ru>
         </text>
         <text name="helpLine_rwe_cat1_bad_title">
             <en>Negative Events (4)</en>
             <uk>Негативні події (4)</uk>
             <da>Negative hændelser (4)</da>
+        
+            <de>[EN] Negative Events (4)</de>
+            <fr>[EN] Negative Events (4)</fr>
+            <pl>[EN] Negative Events (4)</pl>
+            <es>[EN] Negative Events (4)</es>
+            <it>[EN] Negative Events (4)</it>
+            <cz>[EN] Negative Events (4)</cz>
+            <br>[EN] Negative Events (4)</br>
+            <ru>[EN] Negative Events (4)</ru>
         </text>
         <text name="helpLine_rwe_cat1_bad_text">
             <en>Market crashes (reduced sell prices), sudden expenses (immediate cash loss), loan interest charges (percentage of current money), and economic crises (combined market penalty plus ongoing loan costs). High-intensity crises stack both effects. Toggle the Economic category off to disable all of these.</en>
             <uk>Обвали ринку (знижені ціни продажу), раптові витрати (миттєва втрата грошей), нарахування відсотків за кредитом (відсоток від наявних коштів) та економічні кризи (поєднання ринкових штрафів і поточних витрат за кредитом). Кризи високої інтенсивності накопичують обидва ефекти. Вимкніть категорію «Економіка», щоб відключити все це.</uk>
             <da>Markedsnedbrud (reducerede salgspriser), uforudsete udgifter (øjeblikkeligt pengetab), lånerenter (en procentdel af din nuværende saldo) og økonomiske kriser (kombineret markedstraf plus løbende låneomkostninger). Kriser med høj intensitet kombinerer begge effekter. Slå kategorien Økonomi fra for at deaktivere dem alle.</da>
+        
+            <de>[EN] Market crashes (reduced sell prices), sudden expenses (immediate cash loss), loan interest charges (percentage of current money), and economic crises (combined market penalty plus ongoing loan costs). High-intensity crises stack both effects. Toggle the Economic category off to disable all of these.</de>
+            <fr>[EN] Market crashes (reduced sell prices), sudden expenses (immediate cash loss), loan interest charges (percentage of current money), and economic crises (combined market penalty plus ongoing loan costs). High-intensity crises stack both effects. Toggle the Economic category off to disable all of these.</fr>
+            <pl>[EN] Market crashes (reduced sell prices), sudden expenses (immediate cash loss), loan interest charges (percentage of current money), and economic crises (combined market penalty plus ongoing loan costs). High-intensity crises stack both effects. Toggle the Economic category off to disable all of these.</pl>
+            <es>[EN] Market crashes (reduced sell prices), sudden expenses (immediate cash loss), loan interest charges (percentage of current money), and economic crises (combined market penalty plus ongoing loan costs). High-intensity crises stack both effects. Toggle the Economic category off to disable all of these.</es>
+            <it>[EN] Market crashes (reduced sell prices), sudden expenses (immediate cash loss), loan interest charges (percentage of current money), and economic crises (combined market penalty plus ongoing loan costs). High-intensity crises stack both effects. Toggle the Economic category off to disable all of these.</it>
+            <cz>[EN] Market crashes (reduced sell prices), sudden expenses (immediate cash loss), loan interest charges (percentage of current money), and economic crises (combined market penalty plus ongoing loan costs). High-intensity crises stack both effects. Toggle the Economic category off to disable all of these.</cz>
+            <br>[EN] Market crashes (reduced sell prices), sudden expenses (immediate cash loss), loan interest charges (percentage of current money), and economic crises (combined market penalty plus ongoing loan costs). High-intensity crises stack both effects. Toggle the Economic category off to disable all of these.</br>
+            <ru>[EN] Market crashes (reduced sell prices), sudden expenses (immediate cash loss), loan interest charges (percentage of current money), and economic crises (combined market penalty plus ongoing loan costs). High-intensity crises stack both effects. Toggle the Economic category off to disable all of these.</ru>
         </text>
 
         <!-- Help page: Categories / vehicle and field -->
@@ -449,26 +980,71 @@
             <en>Vehicle &amp; Field Events</en>
             <uk>Події з технікою та полями</uk>
             <da>Køretøjs- &amp; markhændelser</da>
+        
+            <de>[EN] Vehicle &amp; Field Events</de>
+            <fr>[EN] Vehicle &amp; Field Events</fr>
+            <pl>[EN] Vehicle &amp; Field Events</pl>
+            <es>[EN] Vehicle &amp; Field Events</es>
+            <it>[EN] Vehicle &amp; Field Events</it>
+            <cz>[EN] Vehicle &amp; Field Events</cz>
+            <br>[EN] Vehicle &amp; Field Events</br>
+            <ru>[EN] Vehicle &amp; Field Events</ru>
         </text>
         <text name="helpLine_rwe_cat2_vehicle_title">
             <en>Vehicle Events (8)</en>
             <uk>Події з технікою (8)</uk>
             <da>Køretøjshændelser (8)</da>
+        
+            <de>[EN] Vehicle Events (8)</de>
+            <fr>[EN] Vehicle Events (8)</fr>
+            <pl>[EN] Vehicle Events (8)</pl>
+            <es>[EN] Vehicle Events (8)</es>
+            <it>[EN] Vehicle Events (8)</it>
+            <cz>[EN] Vehicle Events (8)</cz>
+            <br>[EN] Vehicle Events (8)</br>
+            <ru>[EN] Vehicle Events (8)</ru>
         </text>
         <text name="helpLine_rwe_cat2_vehicle_text">
             <en>Speed boosts, free fuel refills, fuel leaks, minor accidents with repair bills, full fleet cleaning, visual upgrades, engine trouble (reduced power), and emergency repair bills. Most vehicle events target your currently controlled vehicle.</en>
             <uk>Прискорення, безкоштовне поповнення палива, витік палива, дрібні аварії з рахунками за ремонт, повне чищення парку техніки, візуальні оновлення, проблеми з двигуном (знижена потужність) та екстрені рахунки за ремонт. Більшість подій з технікою стосуються транспортного засобу, яким ви керуєте.</uk>
             <da>Hastighedsboosts, gratis brændstofpåfyldninger, brændstoflækager, mindre ulykker med reparationsregninger, rengøring af hele køretøjsflåden, visuelle opgraderinger, motorproblemer (reduceret kraft) samt akutte reparationsregninger. De fleste køretøjshændelser påvirker det køretøj, du aktuelt styrer.</da>
+        
+            <de>[EN] Speed boosts, free fuel refills, fuel leaks, minor accidents with repair bills, full fleet cleaning, visual upgrades, engine trouble (reduced power), and emergency repair bills. Most vehicle events target your currently controlled vehicle.</de>
+            <fr>[EN] Speed boosts, free fuel refills, fuel leaks, minor accidents with repair bills, full fleet cleaning, visual upgrades, engine trouble (reduced power), and emergency repair bills. Most vehicle events target your currently controlled vehicle.</fr>
+            <pl>[EN] Speed boosts, free fuel refills, fuel leaks, minor accidents with repair bills, full fleet cleaning, visual upgrades, engine trouble (reduced power), and emergency repair bills. Most vehicle events target your currently controlled vehicle.</pl>
+            <es>[EN] Speed boosts, free fuel refills, fuel leaks, minor accidents with repair bills, full fleet cleaning, visual upgrades, engine trouble (reduced power), and emergency repair bills. Most vehicle events target your currently controlled vehicle.</es>
+            <it>[EN] Speed boosts, free fuel refills, fuel leaks, minor accidents with repair bills, full fleet cleaning, visual upgrades, engine trouble (reduced power), and emergency repair bills. Most vehicle events target your currently controlled vehicle.</it>
+            <cz>[EN] Speed boosts, free fuel refills, fuel leaks, minor accidents with repair bills, full fleet cleaning, visual upgrades, engine trouble (reduced power), and emergency repair bills. Most vehicle events target your currently controlled vehicle.</cz>
+            <br>[EN] Speed boosts, free fuel refills, fuel leaks, minor accidents with repair bills, full fleet cleaning, visual upgrades, engine trouble (reduced power), and emergency repair bills. Most vehicle events target your currently controlled vehicle.</br>
+            <ru>[EN] Speed boosts, free fuel refills, fuel leaks, minor accidents with repair bills, full fleet cleaning, visual upgrades, engine trouble (reduced power), and emergency repair bills. Most vehicle events target your currently controlled vehicle.</ru>
         </text>
         <text name="helpLine_rwe_cat2_field_title">
             <en>Field Events (10)</en>
             <uk>Події на полях (10)</uk>
             <da>Markhændelser (10)</da>
+        
+            <de>[EN] Field Events (10)</de>
+            <fr>[EN] Field Events (10)</fr>
+            <pl>[EN] Field Events (10)</pl>
+            <es>[EN] Field Events (10)</es>
+            <it>[EN] Field Events (10)</it>
+            <cz>[EN] Field Events (10)</cz>
+            <br>[EN] Field Events (10)</br>
+            <ru>[EN] Field Events (10)</ru>
         </text>
         <text name="helpLine_rwe_cat2_field_text">
             <en>Crop yield bonuses and penalties, doubled or halved fertilizer effectiveness, seed growth speed changes, harvest amount modifiers, and field sale price shifts. Field events require at least one field on the map to be eligible.</en>
             <uk>Бонуси та штрафи до врожайності культур, подвоєна або вдвічі знижена ефективність добрив, зміни швидкості росту насіння, модифікатори кількості врожаю та зміни цін продажу з поля. Для подій на полях потрібне хоча б одне поле на карті.</uk>
             <da>Bonusser og straf på afgrødeudbytte, fordoblet eller halveret effektivitet af gødning, ændringer i frøenes væksthastighed, modifikatorer for høstmængde samt ændringer i markens salgspris. Markhændelser kræver, at der er mindst én mark på kortet for at kunne udløses.</da>
+        
+            <de>[EN] Crop yield bonuses and penalties, doubled or halved fertilizer effectiveness, seed growth speed changes, harvest amount modifiers, and field sale price shifts. Field events require at least one field on the map to be eligible.</de>
+            <fr>[EN] Crop yield bonuses and penalties, doubled or halved fertilizer effectiveness, seed growth speed changes, harvest amount modifiers, and field sale price shifts. Field events require at least one field on the map to be eligible.</fr>
+            <pl>[EN] Crop yield bonuses and penalties, doubled or halved fertilizer effectiveness, seed growth speed changes, harvest amount modifiers, and field sale price shifts. Field events require at least one field on the map to be eligible.</pl>
+            <es>[EN] Crop yield bonuses and penalties, doubled or halved fertilizer effectiveness, seed growth speed changes, harvest amount modifiers, and field sale price shifts. Field events require at least one field on the map to be eligible.</es>
+            <it>[EN] Crop yield bonuses and penalties, doubled or halved fertilizer effectiveness, seed growth speed changes, harvest amount modifiers, and field sale price shifts. Field events require at least one field on the map to be eligible.</it>
+            <cz>[EN] Crop yield bonuses and penalties, doubled or halved fertilizer effectiveness, seed growth speed changes, harvest amount modifiers, and field sale price shifts. Field events require at least one field on the map to be eligible.</cz>
+            <br>[EN] Crop yield bonuses and penalties, doubled or halved fertilizer effectiveness, seed growth speed changes, harvest amount modifiers, and field sale price shifts. Field events require at least one field on the map to be eligible.</br>
+            <ru>[EN] Crop yield bonuses and penalties, doubled or halved fertilizer effectiveness, seed growth speed changes, harvest amount modifiers, and field sale price shifts. Field events require at least one field on the map to be eligible.</ru>
         </text>
 
         <!-- Help page: Categories / special and wildlife -->
@@ -476,26 +1052,71 @@
             <en>Special &amp; Wildlife Events</en>
             <uk>Особливі події та події з дикою природою</uk>
             <da>Særlige &amp; dyrelivshændelser</da>
+        
+            <de>[EN] Special &amp; Wildlife Events</de>
+            <fr>[EN] Special &amp; Wildlife Events</fr>
+            <pl>[EN] Special &amp; Wildlife Events</pl>
+            <es>[EN] Special &amp; Wildlife Events</es>
+            <it>[EN] Special &amp; Wildlife Events</it>
+            <cz>[EN] Special &amp; Wildlife Events</cz>
+            <br>[EN] Special &amp; Wildlife Events</br>
+            <ru>[EN] Special &amp; Wildlife Events</ru>
         </text>
         <text name="helpLine_rwe_cat3_special_title">
             <en>Special Events (10)</en>
             <uk>Особливі події (10)</uk>
             <da>Særlige hændelser (10)</da>
+        
+            <de>[EN] Special Events (10)</de>
+            <fr>[EN] Special Events (10)</fr>
+            <pl>[EN] Special Events (10)</pl>
+            <es>[EN] Special Events (10)</es>
+            <it>[EN] Special Events (10)</it>
+            <cz>[EN] Special Events (10)</cz>
+            <br>[EN] Special Events (10)</br>
+            <ru>[EN] Special Events (10)</ru>
         </text>
         <text name="helpLine_rwe_cat3_special_text">
             <en>Time acceleration and slowdown (affects in-game time scale), XP gain bonuses and penalties, money multipliers, equipment durability changes, better trade prices, and town festivals. Time events restore the original time scale when they end.</en>
             <uk>Прискорення та уповільнення часу (впливає на масштаб ігрового часу), бонуси та штрафи до отримання досвіду, множники грошей, зміни міцності обладнання, кращі торгові ціни та міські фестивалі. Після закінчення часових подій відновлюється початковий масштаб часу.</uk>
             <da>Tidsacceleration og -opbremsning (påvirker spillets tidsskala), bonusser og straf på XP-optjening, pengemultiplikatorer, ændringer i udstyrets holdbarhed, bedre handelspriser samt byfestivaler. Tidsrelaterede hændelser gendanner den oprindelige tidsskala, når de slutter.</da>
+        
+            <de>[EN] Time acceleration and slowdown (affects in-game time scale), XP gain bonuses and penalties, money multipliers, equipment durability changes, better trade prices, and town festivals. Time events restore the original time scale when they end.</de>
+            <fr>[EN] Time acceleration and slowdown (affects in-game time scale), XP gain bonuses and penalties, money multipliers, equipment durability changes, better trade prices, and town festivals. Time events restore the original time scale when they end.</fr>
+            <pl>[EN] Time acceleration and slowdown (affects in-game time scale), XP gain bonuses and penalties, money multipliers, equipment durability changes, better trade prices, and town festivals. Time events restore the original time scale when they end.</pl>
+            <es>[EN] Time acceleration and slowdown (affects in-game time scale), XP gain bonuses and penalties, money multipliers, equipment durability changes, better trade prices, and town festivals. Time events restore the original time scale when they end.</es>
+            <it>[EN] Time acceleration and slowdown (affects in-game time scale), XP gain bonuses and penalties, money multipliers, equipment durability changes, better trade prices, and town festivals. Time events restore the original time scale when they end.</it>
+            <cz>[EN] Time acceleration and slowdown (affects in-game time scale), XP gain bonuses and penalties, money multipliers, equipment durability changes, better trade prices, and town festivals. Time events restore the original time scale when they end.</cz>
+            <br>[EN] Time acceleration and slowdown (affects in-game time scale), XP gain bonuses and penalties, money multipliers, equipment durability changes, better trade prices, and town festivals. Time events restore the original time scale when they end.</br>
+            <ru>[EN] Time acceleration and slowdown (affects in-game time scale), XP gain bonuses and penalties, money multipliers, equipment durability changes, better trade prices, and town festivals. Time events restore the original time scale when they end.</ru>
         </text>
         <text name="helpLine_rwe_cat3_wildlife_title">
             <en>Wildlife Events (10)</en>
             <uk>Події з дикою природою (10)</uk>
             <da>Dyrelivshændelser (10)</da>
+        
+            <de>[EN] Wildlife Events (10)</de>
+            <fr>[EN] Wildlife Events (10)</fr>
+            <pl>[EN] Wildlife Events (10)</pl>
+            <es>[EN] Wildlife Events (10)</es>
+            <it>[EN] Wildlife Events (10)</it>
+            <cz>[EN] Wildlife Events (10)</cz>
+            <br>[EN] Wildlife Events (10)</br>
+            <ru>[EN] Wildlife Events (10)</ru>
         </text>
         <text name="helpLine_rwe_cat3_wildlife_text">
             <en>Bird flocks, beneficial insects, wild stampedes, predator alerts, rabbit infestations, bee swarms, hunting season bonuses, livestock product bonuses and penalties, veterinary bills, and disease scares. Enable the Wildlife category to experience these.</en>
             <uk>Зграї птахів, корисні комахи, дикі натовпи тварин, сповіщення про хижаків, нашестя кролів, рої бджіл, бонуси сезону полювання, бонуси та штрафи до продуктів тваринництва, ветеринарні рахунки та спалахи хвороб. Увімкніть категорію «Дика природа», щоб переживати ці події.</uk>
             <da>Fugleflokke, nyttige insekter, vilde dyreflokke på flugt, rovdyrvarsler, kaninangreb, bisværme, bonusser i jagtsæsonen, bonusser og straf på husdyrprodukter, dyrlægeregninger samt sygdomsbekymringer. Aktivér kategorien Dyreliv for at opleve disse hændelser.</da>
+        
+            <de>[EN] Bird flocks, beneficial insects, wild stampedes, predator alerts, rabbit infestations, bee swarms, hunting season bonuses, livestock product bonuses and penalties, veterinary bills, and disease scares. Enable the Wildlife category to experience these.</de>
+            <fr>[EN] Bird flocks, beneficial insects, wild stampedes, predator alerts, rabbit infestations, bee swarms, hunting season bonuses, livestock product bonuses and penalties, veterinary bills, and disease scares. Enable the Wildlife category to experience these.</fr>
+            <pl>[EN] Bird flocks, beneficial insects, wild stampedes, predator alerts, rabbit infestations, bee swarms, hunting season bonuses, livestock product bonuses and penalties, veterinary bills, and disease scares. Enable the Wildlife category to experience these.</pl>
+            <es>[EN] Bird flocks, beneficial insects, wild stampedes, predator alerts, rabbit infestations, bee swarms, hunting season bonuses, livestock product bonuses and penalties, veterinary bills, and disease scares. Enable the Wildlife category to experience these.</es>
+            <it>[EN] Bird flocks, beneficial insects, wild stampedes, predator alerts, rabbit infestations, bee swarms, hunting season bonuses, livestock product bonuses and penalties, veterinary bills, and disease scares. Enable the Wildlife category to experience these.</it>
+            <cz>[EN] Bird flocks, beneficial insects, wild stampedes, predator alerts, rabbit infestations, bee swarms, hunting season bonuses, livestock product bonuses and penalties, veterinary bills, and disease scares. Enable the Wildlife category to experience these.</cz>
+            <br>[EN] Bird flocks, beneficial insects, wild stampedes, predator alerts, rabbit infestations, bee swarms, hunting season bonuses, livestock product bonuses and penalties, veterinary bills, and disease scares. Enable the Wildlife category to experience these.</br>
+            <ru>[EN] Bird flocks, beneficial insects, wild stampedes, predator alerts, rabbit infestations, bee swarms, hunting season bonuses, livestock product bonuses and penalties, veterinary bills, and disease scares. Enable the Wildlife category to experience these.</ru>
         </text>
 
         <!-- Help page: Settings / event settings -->
@@ -503,26 +1124,71 @@
             <en>Event Settings</en>
             <uk>Налаштування подій</uk>
             <da>Hændelsesindstillinger</da>
+        
+            <de>[EN] Event Settings</de>
+            <fr>[EN] Event Settings</fr>
+            <pl>[EN] Event Settings</pl>
+            <es>[EN] Event Settings</es>
+            <it>[EN] Event Settings</it>
+            <cz>[EN] Event Settings</cz>
+            <br>[EN] Event Settings</br>
+            <ru>[EN] Event Settings</ru>
         </text>
         <text name="helpLine_rwe_set1_freq_title">
             <en>Frequency (1-10)</en>
             <uk>Частота (1–10)</uk>
             <da>Frekvens (1–10)</da>
+        
+            <de>[EN] Frequency (1-10)</de>
+            <fr>[EN] Frequency (1-10)</fr>
+            <pl>[EN] Frequency (1-10)</pl>
+            <es>[EN] Frequency (1-10)</es>
+            <it>[EN] Frequency (1-10)</it>
+            <cz>[EN] Frequency (1-10)</cz>
+            <br>[EN] Frequency (1-10)</br>
+            <ru>[EN] Frequency (1-10)</ru>
         </text>
         <text name="helpLine_rwe_set1_freq_text">
             <en>Controls how often events fire. Higher values increase the per-tick trigger probability. A frequency of 10 means events fire nearly every cooldown period, while 1 makes them very rare. Default is 5 for a balanced experience.</en>
             <uk>Контролює, як часто відбуваються події. Вищі значення збільшують ймовірність запуску за кожен тік. Частота 10 означає, що події відбуваються майже в кожен період перерви, тоді як 1 робить їх дуже рідкісними. За замовчуванням встановлено 5 для збалансованого ігрового процесу.</uk>
             <da>Styrer, hvor ofte hændelser udløses. Højere værdier øger sandsynligheden for udløsning ved hvert tick. En hyppighed på 10 betyder, at hændelser udløses næsten ved hver cooldown-periode, mens 1 gør dem meget sjældne. Standardværdien er 5 for en afbalanceret oplevelse.</da>
+        
+            <de>[EN] Controls how often events fire. Higher values increase the per-tick trigger probability. A frequency of 10 means events fire nearly every cooldown period, while 1 makes them very rare. Default is 5 for a balanced experience.</de>
+            <fr>[EN] Controls how often events fire. Higher values increase the per-tick trigger probability. A frequency of 10 means events fire nearly every cooldown period, while 1 makes them very rare. Default is 5 for a balanced experience.</fr>
+            <pl>[EN] Controls how often events fire. Higher values increase the per-tick trigger probability. A frequency of 10 means events fire nearly every cooldown period, while 1 makes them very rare. Default is 5 for a balanced experience.</pl>
+            <es>[EN] Controls how often events fire. Higher values increase the per-tick trigger probability. A frequency of 10 means events fire nearly every cooldown period, while 1 makes them very rare. Default is 5 for a balanced experience.</es>
+            <it>[EN] Controls how often events fire. Higher values increase the per-tick trigger probability. A frequency of 10 means events fire nearly every cooldown period, while 1 makes them very rare. Default is 5 for a balanced experience.</it>
+            <cz>[EN] Controls how often events fire. Higher values increase the per-tick trigger probability. A frequency of 10 means events fire nearly every cooldown period, while 1 makes them very rare. Default is 5 for a balanced experience.</cz>
+            <br>[EN] Controls how often events fire. Higher values increase the per-tick trigger probability. A frequency of 10 means events fire nearly every cooldown period, while 1 makes them very rare. Default is 5 for a balanced experience.</br>
+            <ru>[EN] Controls how often events fire. Higher values increase the per-tick trigger probability. A frequency of 10 means events fire nearly every cooldown period, while 1 makes them very rare. Default is 5 for a balanced experience.</ru>
         </text>
         <text name="helpLine_rwe_set1_cool_title">
             <en>Intensity (1-5) &amp; Cooldown (1-240 min)</en>
             <uk>Інтенсивність (1–5) та перерва (1–240 хв)</uk>
             <da>Intensitet (1–5) &amp; cooldown (1–240 min.)</da>
+        
+            <de>[EN] Intensity (1-5) &amp; Cooldown (1-240 min)</de>
+            <fr>[EN] Intensity (1-5) &amp; Cooldown (1-240 min)</fr>
+            <pl>[EN] Intensity (1-5) &amp; Cooldown (1-240 min)</pl>
+            <es>[EN] Intensity (1-5) &amp; Cooldown (1-240 min)</es>
+            <it>[EN] Intensity (1-5) &amp; Cooldown (1-240 min)</it>
+            <cz>[EN] Intensity (1-5) &amp; Cooldown (1-240 min)</cz>
+            <br>[EN] Intensity (1-5) &amp; Cooldown (1-240 min)</br>
+            <ru>[EN] Intensity (1-5) &amp; Cooldown (1-240 min)</ru>
         </text>
         <text name="helpLine_rwe_set1_cool_text">
             <en>Intensity scales the magnitude of event effects — use lower values for a gentle experience and higher values for dramatic swings. Cooldown sets the minimum in-game minutes between events. Increase cooldown for a calmer, less frequent experience.</en>
             <uk>Інтенсивність визначає масштаб ефектів подій — використовуйте нижчі значення для спокійного ігрового процесу, а вищі — для драматичних змін. Перерва встановлює мінімальний ігровий час між подіями. Збільшіть перерву для спокійнішого і менш частого ігрового процесу.</uk>
             <da>Intensitet skalerer styrken af hændelsernes effekter — brug lavere værdier for en mere rolig oplevelse og højere værdier for mere dramatiske udsving. Ventetid angiver det minimale antal minutter i spillet mellem hændelser. Øg ventetiden for en roligere oplevelse med færre hændelser.</da>
+        
+            <de>[EN] Intensity scales the magnitude of event effects — use lower values for a gentle experience and higher values for dramatic swings. Cooldown sets the minimum in-game minutes between events. Increase cooldown for a calmer, less frequent experience.</de>
+            <fr>[EN] Intensity scales the magnitude of event effects — use lower values for a gentle experience and higher values for dramatic swings. Cooldown sets the minimum in-game minutes between events. Increase cooldown for a calmer, less frequent experience.</fr>
+            <pl>[EN] Intensity scales the magnitude of event effects — use lower values for a gentle experience and higher values for dramatic swings. Cooldown sets the minimum in-game minutes between events. Increase cooldown for a calmer, less frequent experience.</pl>
+            <es>[EN] Intensity scales the magnitude of event effects — use lower values for a gentle experience and higher values for dramatic swings. Cooldown sets the minimum in-game minutes between events. Increase cooldown for a calmer, less frequent experience.</es>
+            <it>[EN] Intensity scales the magnitude of event effects — use lower values for a gentle experience and higher values for dramatic swings. Cooldown sets the minimum in-game minutes between events. Increase cooldown for a calmer, less frequent experience.</it>
+            <cz>[EN] Intensity scales the magnitude of event effects — use lower values for a gentle experience and higher values for dramatic swings. Cooldown sets the minimum in-game minutes between events. Increase cooldown for a calmer, less frequent experience.</cz>
+            <br>[EN] Intensity scales the magnitude of event effects — use lower values for a gentle experience and higher values for dramatic swings. Cooldown sets the minimum in-game minutes between events. Increase cooldown for a calmer, less frequent experience.</br>
+            <ru>[EN] Intensity scales the magnitude of event effects — use lower values for a gentle experience and higher values for dramatic swings. Cooldown sets the minimum in-game minutes between events. Increase cooldown for a calmer, less frequent experience.</ru>
         </text>
 
         <!-- Help page: Settings / physics settings -->
@@ -530,26 +1196,71 @@
             <en>Physics Settings</en>
             <uk>Налаштування фізики</uk>
             <da>Fysiske indstillinger</da>
+        
+            <de>[EN] Physics Settings</de>
+            <fr>[EN] Physics Settings</fr>
+            <pl>[EN] Physics Settings</pl>
+            <es>[EN] Physics Settings</es>
+            <it>[EN] Physics Settings</it>
+            <cz>[EN] Physics Settings</cz>
+            <br>[EN] Physics Settings</br>
+            <ru>[EN] Physics Settings</ru>
         </text>
         <text name="helpLine_rwe_set2_grip_title">
             <en>Wheel Grip &amp; Suspension</en>
             <uk>Зчеплення коліс та підвіска</uk>
             <da>Hjulgreb &amp; affjedring</da>
+        
+            <de>[EN] Wheel Grip &amp; Suspension</de>
+            <fr>[EN] Wheel Grip &amp; Suspension</fr>
+            <pl>[EN] Wheel Grip &amp; Suspension</pl>
+            <es>[EN] Wheel Grip &amp; Suspension</es>
+            <it>[EN] Wheel Grip &amp; Suspension</it>
+            <cz>[EN] Wheel Grip &amp; Suspension</cz>
+            <br>[EN] Wheel Grip &amp; Suspension</br>
+            <ru>[EN] Wheel Grip &amp; Suspension</ru>
         </text>
         <text name="helpLine_rwe_set2_grip_text">
             <en>The physics system applies terrain-aware wheel friction to your controlled vehicle every frame. Asphalt gives 110% grip, dirt 95%, fields 85%, grass 90%, and snow 70%. The Wheel Grip Multiplier scales all of these values. Suspension Stiffness multiplies spring force.</en>
             <uk>Система фізики застосовує зчеплення коліс залежно від типу поверхні для вашого транспортного засобу щокадру. Асфальт дає 110% зчеплення, бруд — 95%, поля — 85%, трава — 90%, сніг — 70%. Множник зчеплення коліс масштабує всі ці значення. Жорсткість підвіски множить силу пружини.</uk>
             <da>Fysiksystemet anvender terræntilpasset hjulfriktion på det køretøj, du styrer, i hver frame. Asfalt giver 110 % greb, jord 95 %, marker 85 %, græs 90 % og sne 70 %. Multiplikatoren for hjulgreb skalerer alle disse værdier. Affjedringsstivhed multiplicerer fjederkraften.</da>
+        
+            <de>[EN] The physics system applies terrain-aware wheel friction to your controlled vehicle every frame. Asphalt gives 110% grip, dirt 95%, fields 85%, grass 90%, and snow 70%. The Wheel Grip Multiplier scales all of these values. Suspension Stiffness multiplies spring force.</de>
+            <fr>[EN] The physics system applies terrain-aware wheel friction to your controlled vehicle every frame. Asphalt gives 110% grip, dirt 95%, fields 85%, grass 90%, and snow 70%. The Wheel Grip Multiplier scales all of these values. Suspension Stiffness multiplies spring force.</fr>
+            <pl>[EN] The physics system applies terrain-aware wheel friction to your controlled vehicle every frame. Asphalt gives 110% grip, dirt 95%, fields 85%, grass 90%, and snow 70%. The Wheel Grip Multiplier scales all of these values. Suspension Stiffness multiplies spring force.</pl>
+            <es>[EN] The physics system applies terrain-aware wheel friction to your controlled vehicle every frame. Asphalt gives 110% grip, dirt 95%, fields 85%, grass 90%, and snow 70%. The Wheel Grip Multiplier scales all of these values. Suspension Stiffness multiplies spring force.</es>
+            <it>[EN] The physics system applies terrain-aware wheel friction to your controlled vehicle every frame. Asphalt gives 110% grip, dirt 95%, fields 85%, grass 90%, and snow 70%. The Wheel Grip Multiplier scales all of these values. Suspension Stiffness multiplies spring force.</it>
+            <cz>[EN] The physics system applies terrain-aware wheel friction to your controlled vehicle every frame. Asphalt gives 110% grip, dirt 95%, fields 85%, grass 90%, and snow 70%. The Wheel Grip Multiplier scales all of these values. Suspension Stiffness multiplies spring force.</cz>
+            <br>[EN] The physics system applies terrain-aware wheel friction to your controlled vehicle every frame. Asphalt gives 110% grip, dirt 95%, fields 85%, grass 90%, and snow 70%. The Wheel Grip Multiplier scales all of these values. Suspension Stiffness multiplies spring force.</br>
+            <ru>[EN] The physics system applies terrain-aware wheel friction to your controlled vehicle every frame. Asphalt gives 110% grip, dirt 95%, fields 85%, grass 90%, and snow 70%. The Wheel Grip Multiplier scales all of these values. Suspension Stiffness multiplies spring force.</ru>
         </text>
         <text name="helpLine_rwe_set2_debug_title">
             <en>Debug &amp; Physics Info</en>
             <uk>Налагодження та інформація про фізику</uk>
             <da>Fejlfinding &amp; Fysisk info</da>
+        
+            <de>[EN] Debug &amp; Physics Info</de>
+            <fr>[EN] Debug &amp; Physics Info</fr>
+            <pl>[EN] Debug &amp; Physics Info</pl>
+            <es>[EN] Debug &amp; Physics Info</es>
+            <it>[EN] Debug &amp; Physics Info</it>
+            <cz>[EN] Debug &amp; Physics Info</cz>
+            <br>[EN] Debug &amp; Physics Info</br>
+            <ru>[EN] Debug &amp; Physics Info</ru>
         </text>
         <text name="helpLine_rwe_set2_debug_text">
             <en>Enable Show Physics Info to log per-vehicle speed and multiplier data each frame. Enable Debug Mode for per-wheel grip values. These are useful for tuning your physics settings but may produce verbose console output during normal play.</en>
             <uk>Увімкніть «Показати інформацію про фізику», щоб записувати дані швидкості та множника для кожного транспортного засобу щокадру. Увімкніть режим налагодження для перегляду значень зчеплення кожного колеса. Це корисно для налаштування параметрів фізики, але може призвести до детального виводу в консоль під час звичайної гри.</uk>
             <da>Aktivér Vis fysikinfo for at logge hastigheds- og multiplikatordata pr. køretøj i hver frame. Aktivér Debugtilstand for grebsværdier pr. hjul. Disse er nyttige til finjustering af dine fysikindstillinger, men kan give meget detaljeret konsoloutput under normal spilbrug.</da>
+        
+            <de>[EN] Enable Show Physics Info to log per-vehicle speed and multiplier data each frame. Enable Debug Mode for per-wheel grip values. These are useful for tuning your physics settings but may produce verbose console output during normal play.</de>
+            <fr>[EN] Enable Show Physics Info to log per-vehicle speed and multiplier data each frame. Enable Debug Mode for per-wheel grip values. These are useful for tuning your physics settings but may produce verbose console output during normal play.</fr>
+            <pl>[EN] Enable Show Physics Info to log per-vehicle speed and multiplier data each frame. Enable Debug Mode for per-wheel grip values. These are useful for tuning your physics settings but may produce verbose console output during normal play.</pl>
+            <es>[EN] Enable Show Physics Info to log per-vehicle speed and multiplier data each frame. Enable Debug Mode for per-wheel grip values. These are useful for tuning your physics settings but may produce verbose console output during normal play.</es>
+            <it>[EN] Enable Show Physics Info to log per-vehicle speed and multiplier data each frame. Enable Debug Mode for per-wheel grip values. These are useful for tuning your physics settings but may produce verbose console output during normal play.</it>
+            <cz>[EN] Enable Show Physics Info to log per-vehicle speed and multiplier data each frame. Enable Debug Mode for per-wheel grip values. These are useful for tuning your physics settings but may produce verbose console output during normal play.</cz>
+            <br>[EN] Enable Show Physics Info to log per-vehicle speed and multiplier data each frame. Enable Debug Mode for per-wheel grip values. These are useful for tuning your physics settings but may produce verbose console output during normal play.</br>
+            <ru>[EN] Enable Show Physics Info to log per-vehicle speed and multiplier data each frame. Enable Debug Mode for per-wheel grip values. These are useful for tuning your physics settings but may produce verbose console output during normal play.</ru>
         </text>
 
         <!-- Help page: Controls -->
@@ -557,26 +1268,71 @@
             <en>Controls &amp; Console Commands</en>
             <uk>Керування та консольні команди</uk>
             <da>Styring &amp; kommandoer</da>
+        
+            <de>[EN] Controls &amp; Console Commands</de>
+            <fr>[EN] Controls &amp; Console Commands</fr>
+            <pl>[EN] Controls &amp; Console Commands</pl>
+            <es>[EN] Controls &amp; Console Commands</es>
+            <it>[EN] Controls &amp; Console Commands</it>
+            <cz>[EN] Controls &amp; Console Commands</cz>
+            <br>[EN] Controls &amp; Console Commands</br>
+            <ru>[EN] Controls &amp; Console Commands</ru>
         </text>
         <text name="helpLine_rwe_ctrl_keys_title">
             <en>Keyboard Shortcuts</en>
             <uk>Гарячі клавіші</uk>
             <da>Genvejstaster</da>
+        
+            <de>[EN] Keyboard Shortcuts</de>
+            <fr>[EN] Keyboard Shortcuts</fr>
+            <pl>[EN] Keyboard Shortcuts</pl>
+            <es>[EN] Keyboard Shortcuts</es>
+            <it>[EN] Keyboard Shortcuts</it>
+            <cz>[EN] Keyboard Shortcuts</cz>
+            <br>[EN] Keyboard Shortcuts</br>
+            <ru>[EN] Keyboard Shortcuts</ru>
         </text>
         <text name="helpLine_rwe_ctrl_keys_text">
             <en>F3: Open the Random World Events settings screen. F9: Immediately force-trigger a random event (useful for testing). These bindings can be changed in the game's keybinding menu under the Random World Events section.</en>
             <uk>F3: Відкрити екран налаштувань випадкових світових подій. F9: Негайно примусово запустити випадкову подію (корисно для тестування). Ці прив'язки можна змінити в меню прив'язок клавіш гри в розділі «Випадкові світові події».</uk>
             <da>F3: Åbn indstillingsskærmen for Random World Events. F9: Tving straks en tilfældig hændelse til at udløses (nyttigt til test). Disse tastetildelinger kan ændres i spillets menu for tastetildelinger under sektionen Random World Events.</da>
+        
+            <de>[EN] F3: Open the Random World Events settings screen. F9: Immediately force-trigger a random event (useful for testing). These bindings can be changed in the game's keybinding menu under the Random World Events section.</de>
+            <fr>[EN] F3: Open the Random World Events settings screen. F9: Immediately force-trigger a random event (useful for testing). These bindings can be changed in the game's keybinding menu under the Random World Events section.</fr>
+            <pl>[EN] F3: Open the Random World Events settings screen. F9: Immediately force-trigger a random event (useful for testing). These bindings can be changed in the game's keybinding menu under the Random World Events section.</pl>
+            <es>[EN] F3: Open the Random World Events settings screen. F9: Immediately force-trigger a random event (useful for testing). These bindings can be changed in the game's keybinding menu under the Random World Events section.</es>
+            <it>[EN] F3: Open the Random World Events settings screen. F9: Immediately force-trigger a random event (useful for testing). These bindings can be changed in the game's keybinding menu under the Random World Events section.</it>
+            <cz>[EN] F3: Open the Random World Events settings screen. F9: Immediately force-trigger a random event (useful for testing). These bindings can be changed in the game's keybinding menu under the Random World Events section.</cz>
+            <br>[EN] F3: Open the Random World Events settings screen. F9: Immediately force-trigger a random event (useful for testing). These bindings can be changed in the game's keybinding menu under the Random World Events section.</br>
+            <ru>[EN] F3: Open the Random World Events settings screen. F9: Immediately force-trigger a random event (useful for testing). These bindings can be changed in the game's keybinding menu under the Random World Events section.</ru>
         </text>
         <text name="helpLine_rwe_ctrl_console_title">
             <en>Console Commands</en>
             <uk>Консольні команди</uk>
             <da>Kommandoer</da>
+        
+            <de>[EN] Console Commands</de>
+            <fr>[EN] Console Commands</fr>
+            <pl>[EN] Console Commands</pl>
+            <es>[EN] Console Commands</es>
+            <it>[EN] Console Commands</it>
+            <cz>[EN] Console Commands</cz>
+            <br>[EN] Console Commands</br>
+            <ru>[EN] Console Commands</ru>
         </text>
         <text name="helpLine_rwe_ctrl_console_text">
             <en>Open the developer console and type: rwe (help), rweStatus (current state), rweTest (force trigger), rweEnd (stop active event), rweSettings (open GUI), rweDebug on|off (toggle verbose logging), rweList [category] (list all events).</en>
             <uk>Відкрийте консоль розробника та введіть: rwe (допомога), rweStatus (поточний стан), rweTest (примусовий запуск), rweEnd (зупинити активну подію), rweSettings (відкрити інтерфейс), rweDebug on|off (перемкнути детальне журналювання), rweList [категорія] (список усіх подій).</uk>
             <da>Åbn udviklerkonsollen og skriv: rwe (hjælp), rweStatus (nuværende status), rweTest (tving en hændelse til at udløses), rweEnd (stop aktiv hændelse), rweSettings (åbn GUI), rweDebug on|off (slå detaljeret logning til/fra), rweList [kategori] (vis alle hændelser).</da>
+        
+            <de>[EN] Open the developer console and type: rwe (help), rweStatus (current state), rweTest (force trigger), rweEnd (stop active event), rweSettings (open GUI), rweDebug on|off (toggle verbose logging), rweList [category] (list all events).</de>
+            <fr>[EN] Open the developer console and type: rwe (help), rweStatus (current state), rweTest (force trigger), rweEnd (stop active event), rweSettings (open GUI), rweDebug on|off (toggle verbose logging), rweList [category] (list all events).</fr>
+            <pl>[EN] Open the developer console and type: rwe (help), rweStatus (current state), rweTest (force trigger), rweEnd (stop active event), rweSettings (open GUI), rweDebug on|off (toggle verbose logging), rweList [category] (list all events).</pl>
+            <es>[EN] Open the developer console and type: rwe (help), rweStatus (current state), rweTest (force trigger), rweEnd (stop active event), rweSettings (open GUI), rweDebug on|off (toggle verbose logging), rweList [category] (list all events).</es>
+            <it>[EN] Open the developer console and type: rwe (help), rweStatus (current state), rweTest (force trigger), rweEnd (stop active event), rweSettings (open GUI), rweDebug on|off (toggle verbose logging), rweList [category] (list all events).</it>
+            <cz>[EN] Open the developer console and type: rwe (help), rweStatus (current state), rweTest (force trigger), rweEnd (stop active event), rweSettings (open GUI), rweDebug on|off (toggle verbose logging), rweList [category] (list all events).</cz>
+            <br>[EN] Open the developer console and type: rwe (help), rweStatus (current state), rweTest (force trigger), rweEnd (stop active event), rweSettings (open GUI), rweDebug on|off (toggle verbose logging), rweList [category] (list all events).</br>
+            <ru>[EN] Open the developer console and type: rwe (help), rweStatus (current state), rweTest (force trigger), rweEnd (stop active event), rweSettings (open GUI), rweDebug on|off (toggle verbose logging), rweList [category] (list all events).</ru>
         </text>
 
         <!-- HUD overlay strings -->

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
     <version>2.1.6.1</version>
@@ -120,7 +120,7 @@
             <uk>Розклад подій</uk>
             <da>Interval for hændelser</da>
         
-            <de>[EN] Event Timing</de>
+            <de>Event Zeitpunkt</de>
             <fr>[EN] Event Timing</fr>
             <pl>[EN] Event Timing</pl>
             <es>[EN] Event Timing</es>
@@ -134,7 +134,7 @@
             <uk>Сповіщення та HUD</uk>
             <da>Notifikationer &amp; HUD</da>
         
-            <de>[EN] Notifications &amp; HUD</de>
+            <de>HUD Benachrichtigung </de>
             <fr>[EN] Notifications &amp; HUD</fr>
             <pl>[EN] Notifications &amp; HUD</pl>
             <es>[EN] Notifications &amp; HUD</es>
@@ -148,7 +148,7 @@
             <uk>Категорії подій</uk>
             <da>Hændelsestyper</da>
         
-            <de>[EN] Event Categories</de>
+            <de>Eventkategorien</de>
             <fr>[EN] Event Categories</fr>
             <pl>[EN] Event Categories</pl>
             <es>[EN] Event Categories</es>
@@ -162,7 +162,7 @@
             <uk>Налаштування фізики</uk>
             <da>Fysikoverstyring</da>
         
-            <de>[EN] Physics Override</de>
+            <de>Überschreibung der Mechanik</de>
             <fr>[EN] Physics Override</fr>
             <pl>[EN] Physics Override</pl>
             <es>[EN] Physics Override</es>
@@ -176,7 +176,7 @@
             <uk>Налагодження</uk>
             <da>Fejlfinding</da>
         
-            <de>[EN] Debug</de>
+            <de>Debug</de>
             <fr>[EN] Debug</fr>
             <pl>[EN] Debug</pl>
             <es>[EN] Debug</es>
@@ -192,7 +192,7 @@
             <uk>Частота</uk>
             <da>Frekvens</da>
         
-            <de>[EN] Frequency</de>
+            <de>Häufigkeit</de>
             <fr>[EN] Frequency</fr>
             <pl>[EN] Frequency</pl>
             <es>[EN] Frequency</es>
@@ -206,7 +206,7 @@
             <uk>Як часто виникають події (1 = рідко, 10 = часто)</uk>
             <da>Hvor ofte hændelser udløses (1 = sjældent, 10 = ofte)</da>
         
-            <de>[EN] How often events fire (1 = rare, 10 = frequent)</de>
+            <de>Wie häufig Events kommen (1 = selten, 10 = häufig)</de>
             <fr>[EN] How often events fire (1 = rare, 10 = frequent)</fr>
             <pl>[EN] How often events fire (1 = rare, 10 = frequent)</pl>
             <es>[EN] How often events fire (1 = rare, 10 = frequent)</es>
@@ -220,7 +220,7 @@
             <uk>Інтенсивність</uk>
             <da>Styrke</da>
         
-            <de>[EN] Intensity</de>
+            <de>Intensität</de>
             <fr>[EN] Intensity</fr>
             <pl>[EN] Intensity</pl>
             <es>[EN] Intensity</es>
@@ -234,7 +234,7 @@
             <uk>Сила ефектів подій (1 = слабка, 5 = екстремальна)</uk>
             <da>Styrken af hændelseseffekter (1 = mild, 5 = ekstrem)</da>
         
-            <de>[EN] Strength of event effects (1 = mild, 5 = extreme)</de>
+            <de>Stärke der Weltereignisse (1 = schwach, 5 = extrem)</de>
             <fr>[EN] Strength of event effects (1 = mild, 5 = extreme)</fr>
             <pl>[EN] Strength of event effects (1 = mild, 5 = extreme)</pl>
             <es>[EN] Strength of event effects (1 = mild, 5 = extreme)</es>
@@ -248,7 +248,7 @@
             <uk>Перерва</uk>
             <da>Cooldown</da>
         
-            <de>[EN] Cooldown</de>
+            <de>Abklingzeit</de>
             <fr>[EN] Cooldown</fr>
             <pl>[EN] Cooldown</pl>
             <es>[EN] Cooldown</es>
@@ -262,7 +262,7 @@
             <uk>Мінімальний ігровий час між подіями</uk>
             <da>Minimum in-game tid mellem hændelser</da>
         
-            <de>[EN] Minimum in-game time between events</de>
+            <de>Mindestzeit (Ingame) zwischen den Ereignissen</de>
             <fr>[EN] Minimum in-game time between events</fr>
             <pl>[EN] Minimum in-game time between events</pl>
             <es>[EN] Minimum in-game time between events</es>
@@ -278,7 +278,7 @@
             <uk>Показувати сповіщення</uk>
             <da>Vis Notifikationer</da>
         
-            <de>[EN] Show Notifications</de>
+            <de>Zeige Benachrichtigungen</de>
             <fr>[EN] Show Notifications</fr>
             <pl>[EN] Show Notifications</pl>
             <es>[EN] Show Notifications</es>
@@ -292,7 +292,7 @@
             <uk>Відображати сповіщення про події на екрані</uk>
             <da>Vis hændelsesnotifikationer på skærmen</da>
         
-            <de>[EN] Display event notifications on screen</de>
+            <de>Zeige die Benachrichtigungen auf dem Bildschirm</de>
             <fr>[EN] Display event notifications on screen</fr>
             <pl>[EN] Display event notifications on screen</pl>
             <es>[EN] Display event notifications on screen</es>
@@ -306,7 +306,7 @@
             <uk>Показувати попередження</uk>
             <da>Vis Advarsler</da>
         
-            <de>[EN] Show Warnings</de>
+            <de>Zeige Warnungen</de>
             <fr>[EN] Show Warnings</fr>
             <pl>[EN] Show Warnings</pl>
             <es>[EN] Show Warnings</es>
@@ -320,7 +320,7 @@
             <uk>Відображати попереджувальні повідомлення про події</uk>
             <da>Vis hændelsesadvarsler</da>
         
-            <de>[EN] Show event warning messages</de>
+            <de>Zeige Warnungen der Weltereignisse</de>
             <fr>[EN] Show event warning messages</fr>
             <pl>[EN] Show event warning messages</pl>
             <es>[EN] Show event warning messages</es>
@@ -334,7 +334,7 @@
             <uk>Показати панель HUD</uk>
             <da>Vis HUD-panel</da>
         
-            <de>[EN] Show HUD Panel</de>
+            <de>Zeige HUD Panel</de>
             <fr>[EN] Show HUD Panel</fr>
             <pl>[EN] Show HUD Panel</pl>
             <es>[EN] Show HUD Panel</es>
@@ -348,7 +348,7 @@
             <uk>Показати накладку HUD світових подій (F3 для перемикання в грі)</uk>
             <da>Vis HUD-overlayet for hændelser (F3 for at slå til/fra i spillet)</da>
         
-            <de>[EN] Show the World Events HUD overlay (F3 to toggle in-game)</de>
+            <de>Zeige das Weltereignisse HUD (F3 zum Umschalten)</de>
             <fr>[EN] Show the World Events HUD overlay (F3 to toggle in-game)</fr>
             <pl>[EN] Show the World Events HUD overlay (F3 to toggle in-game)</pl>
             <es>[EN] Show the World Events HUD overlay (F3 to toggle in-game)</es>
@@ -362,7 +362,7 @@
             <uk>Масштаб HUD</uk>
             <da>HUD-skala</da>
         
-            <de>[EN] HUD Scale</de>
+            <de>HUD-Skalierung</de>
             <fr>[EN] HUD Scale</fr>
             <pl>[EN] HUD Scale</pl>
             <es>[EN] HUD Scale</es>
@@ -376,7 +376,7 @@
             <uk>Розмір панелі HUD світових подій</uk>
             <da>Størrelse på HUD-panelet for hændelser</da>
         
-            <de>[EN] Size of the World Events HUD panel</de>
+            <de>Größe des Weltereignisse HUD</de>
             <fr>[EN] Size of the World Events HUD panel</fr>
             <pl>[EN] Size of the World Events HUD panel</pl>
             <es>[EN] Size of the World Events HUD panel</es>
@@ -392,7 +392,7 @@
             <uk>Економічні події</uk>
             <da>Økonomiske hændelser</da>
         
-            <de>[EN] Economic Events</de>
+            <de>Wirtschaftsereignisse</de>
             <fr>[EN] Economic Events</fr>
             <pl>[EN] Economic Events</pl>
             <es>[EN] Economic Events</es>
@@ -406,7 +406,7 @@
             <uk>Увімкнути ринкові та економічні події</uk>
             <da>Slå markeds- og økonomiske hændelser til</da>
         
-            <de>[EN] Enable market and economic events</de>
+            <de>Markt- und Wirtschaftsereignisse aktivieren</de>
             <fr>[EN] Enable market and economic events</fr>
             <pl>[EN] Enable market and economic events</pl>
             <es>[EN] Enable market and economic events</es>
@@ -420,7 +420,7 @@
             <uk>Події з технікою</uk>
             <da>Køretøjshændelser</da>
         
-            <de>[EN] Vehicle Events</de>
+            <de>Fahrzeugereignisse</de>
             <fr>[EN] Vehicle Events</fr>
             <pl>[EN] Vehicle Events</pl>
             <es>[EN] Vehicle Events</es>
@@ -434,7 +434,7 @@
             <uk>Увімкнути події з технікою (швидкість, паливо, пошкодження)</uk>
             <da>Aktivér køretøjshændelser (hastighed, brændstof, skader)</da>
         
-            <de>[EN] Enable vehicle events (speed, fuel, damage)</de>
+            <de>Aktiviere Fahrzeugereignisse (Geschwindigkeit, Verbrauch, Schaden)</de>
             <fr>[EN] Enable vehicle events (speed, fuel, damage)</fr>
             <pl>[EN] Enable vehicle events (speed, fuel, damage)</pl>
             <es>[EN] Enable vehicle events (speed, fuel, damage)</es>
@@ -448,7 +448,7 @@
             <uk>Події на полях</uk>
             <da>Markhændelser</da>
         
-            <de>[EN] Field Events</de>
+            <de>Feldereignisse</de>
             <fr>[EN] Field Events</fr>
             <pl>[EN] Field Events</pl>
             <es>[EN] Field Events</es>
@@ -462,7 +462,7 @@
             <uk>Увімкнути події з культурами та полями</uk>
             <da>Aktivér afgrøde- og markhændelser</da>
         
-            <de>[EN] Enable crop and field events</de>
+            <de>Aktiviere Ernte- und Feldereignisse</de>
             <fr>[EN] Enable crop and field events</fr>
             <pl>[EN] Enable crop and field events</pl>
             <es>[EN] Enable crop and field events</es>
@@ -476,7 +476,7 @@
             <uk>Події з дикою природою</uk>
             <da>Dyrelivshændelser</da>
         
-            <de>[EN] Wildlife Events</de>
+            <de>Wildtierereignisse</de>
             <fr>[EN] Wildlife Events</fr>
             <pl>[EN] Wildlife Events</pl>
             <es>[EN] Wildlife Events</es>
@@ -490,7 +490,7 @@
             <uk>Увімкнути події з дикою природою та тваринами</uk>
             <da>Aktivér hændelser med dyreliv og dyr</da>
         
-            <de>[EN] Enable wildlife and animal events</de>
+            <de>Wildtierereignisse aktivieren</de>
             <fr>[EN] Enable wildlife and animal events</fr>
             <pl>[EN] Enable wildlife and animal events</pl>
             <es>[EN] Enable wildlife and animal events</es>
@@ -504,7 +504,7 @@
             <uk>Особливі події</uk>
             <da>Særlige hændelser</da>
         
-            <de>[EN] Special Events</de>
+            <de>Spezialereignisse</de>
             <fr>[EN] Special Events</fr>
             <pl>[EN] Special Events</pl>
             <es>[EN] Special Events</es>
@@ -518,7 +518,7 @@
             <uk>Увімкнути події з часом, досвідом та особливі події</uk>
             <da>Aktivér tids-, XP- og Særlige hændelser</da>
         
-            <de>[EN] Enable time, XP, and special events</de>
+            <de>Zeit-, EP- und Spezialereignisse aktivieren</de>
             <fr>[EN] Enable time, XP, and special events</fr>
             <pl>[EN] Enable time, XP, and special events</pl>
             <es>[EN] Enable time, XP, and special events</es>
@@ -534,7 +534,7 @@
             <uk>Увімкнути налаштування фізики</uk>
             <da>Aktivér fysikoverstyring</da>
         
-            <de>[EN] Enable Physics Override</de>
+            <de>Spielphysik überschreiben aktivieren</de>
             <fr>[EN] Enable Physics Override</fr>
             <pl>[EN] Enable Physics Override</pl>
             <es>[EN] Enable Physics Override</es>
@@ -548,7 +548,7 @@
             <uk>Застосувати зчеплення коліс і підвіску залежно від типу поверхні</uk>
             <da>Anvend terræntilpasset hjulgreb og affjedring</da>
         
-            <de>[EN] Apply terrain-aware wheel grip and suspension</de>
+            <de>Aktiviere dynamischen Schlupf und Federung</de>
             <fr>[EN] Apply terrain-aware wheel grip and suspension</fr>
             <pl>[EN] Apply terrain-aware wheel grip and suspension</pl>
             <es>[EN] Apply terrain-aware wheel grip and suspension</es>
@@ -562,7 +562,7 @@
             <uk>Зчеплення коліс</uk>
             <da>hjulgreb</da>
         
-            <de>[EN] Wheel Grip</de>
+            <de>Radschlupf</de>
             <fr>[EN] Wheel Grip</fr>
             <pl>[EN] Wheel Grip</pl>
             <es>[EN] Wheel Grip</es>
@@ -576,7 +576,7 @@
             <uk>Масштаб зчеплення з поверхнею (1.00 = за замовчуванням)</uk>
             <da>Skaler terrænets grebsværdier (1,00 = standard)</da>
         
-            <de>[EN] Scale terrain grip values (1.00 = default)</de>
+            <de>Radschlupf einstellen (1.00 = default)</de>
             <fr>[EN] Scale terrain grip values (1.00 = default)</fr>
             <pl>[EN] Scale terrain grip values (1.00 = default)</pl>
             <es>[EN] Scale terrain grip values (1.00 = default)</es>
@@ -590,7 +590,7 @@
             <uk>Жорсткість підвіски</uk>
             <da>Affjedringsstivhed</da>
         
-            <de>[EN] Suspension Stiffness</de>
+            <de>Federhärte</de>
             <fr>[EN] Suspension Stiffness</fr>
             <pl>[EN] Suspension Stiffness</pl>
             <es>[EN] Suspension Stiffness</es>
@@ -604,7 +604,7 @@
             <uk>Масштаб сили пружини підвіски (1.00 = за замовчуванням)</uk>
             <da>Skaler affjedringens fjederkraft (1,00 = standard)</da>
         
-            <de>[EN] Scale suspension spring force (1.00 = default)</de>
+            <de>Federhärte einstellen (1.00 = default)</de>
             <fr>[EN] Scale suspension spring force (1.00 = default)</fr>
             <pl>[EN] Scale suspension spring force (1.00 = default)</pl>
             <es>[EN] Scale suspension spring force (1.00 = default)</es>
@@ -620,7 +620,7 @@
             <uk>Показати інформацію про фізику</uk>
             <da>Vis fysikinfo</da>
         
-            <de>[EN] Show Physics Info</de>
+            <de>Info zur Physik zeigen</de>
             <fr>[EN] Show Physics Info</fr>
             <pl>[EN] Show Physics Info</pl>
             <es>[EN] Show Physics Info</es>
@@ -634,7 +634,7 @@
             <uk>Записувати дані швидкості та зчеплення для кожного транспортного засобу щокадру</uk>
             <da>Log hastigheds- og grebsdata pr. køretøj i hver frame</da>
         
-            <de>[EN] Log per-vehicle speed and grip data each frame</de>
+            <de>Log pro Fahrzeug und Frame (Geschwindigkeit, Schlupf) </de>
             <fr>[EN] Log per-vehicle speed and grip data each frame</fr>
             <pl>[EN] Log per-vehicle speed and grip data each frame</pl>
             <es>[EN] Log per-vehicle speed and grip data each frame</es>
@@ -648,7 +648,7 @@
             <uk>Режим налагодження</uk>
             <da>Fejlfindingstilstand</da>
         
-            <de>[EN] Debug Mode</de>
+            <de>Debugmodus</de>
             <fr>[EN] Debug Mode</fr>
             <pl>[EN] Debug Mode</pl>
             <es>[EN] Debug Mode</es>
@@ -662,7 +662,7 @@
             <uk>Показувати детальні діагностичні дані випадкових світових подій</uk>
             <da>Vis detaljeret debugoutput for tilfældige hændelser</da>
         
-            <de>[EN] Show verbose Random World Events debug output</de>
+            <de>Zeige den Debug-Output der Weltereignisse</de>
             <fr>[EN] Show verbose Random World Events debug output</fr>
             <pl>[EN] Show verbose Random World Events debug output</pl>
             <es>[EN] Show verbose Random World Events debug output</es>
@@ -678,7 +678,7 @@
             <uk>Перемкнути HUD випадкових світових подій</uk>
             <da>Skift tilfældige hændelser HUD</da>
         
-            <de>[EN] Toggle Random World Events HUD</de>
+            <de>Zufällige Weltereignisse HUD ein- und ausschalten</de>
             <fr>[EN] Toggle Random World Events HUD</fr>
             <pl>[EN] Toggle Random World Events HUD</pl>
             <es>[EN] Toggle Random World Events HUD</es>
@@ -707,7 +707,7 @@
             <uk>Огляд</uk>
             <da>Oversigt</da>
         
-            <de>[EN] Overview</de>
+            <de>Übersicht</de>
             <fr>[EN] Overview</fr>
             <pl>[EN] Overview</pl>
             <es>[EN] Overview</es>
@@ -721,7 +721,7 @@
             <uk>Категорії подій</uk>
             <da>Hændelseskategorier</da>
         
-            <de>[EN] Event Categories</de>
+            <de>Eventkategorien</de>
             <fr>[EN] Event Categories</fr>
             <pl>[EN] Event Categories</pl>
             <es>[EN] Event Categories</es>
@@ -735,7 +735,7 @@
             <uk>Налаштування</uk>
             <da>indstillinger</da>
         
-            <de>[EN] Settings</de>
+            <de>Einstellungen</de>
             <fr>[EN] Settings</fr>
             <pl>[EN] Settings</pl>
             <es>[EN] Settings</es>
@@ -749,7 +749,7 @@
             <uk>Керування та команди</uk>
             <da>Styring &amp; kommandoer</da>
         
-            <de>[EN] Controls &amp; Commands</de>
+            <de>Tastaturbefehle</de>
             <fr>[EN] Controls &amp; Commands</fr>
             <pl>[EN] Controls &amp; Commands</pl>
             <es>[EN] Controls &amp; Commands</es>
@@ -765,7 +765,7 @@
             <uk>Що таке випадкові світові події?</uk>
             <da> Hvad er Random World Events</da>
         
-            <de>[EN] What is Random World Events?</de>
+            <de>Was sind zufällige Weltereignisse?</de>
             <fr>[EN] What is Random World Events?</fr>
             <pl>[EN] What is Random World Events?</pl>
             <es>[EN] What is Random World Events?</es>
@@ -779,7 +779,7 @@
             <uk>Живий світ</uk>
             <da>Levende verden</da>
         
-            <de>[EN] Living World</de>
+            <de>Lebendige Welt</de>
             <fr>[EN] Living World</fr>
             <pl>[EN] Living World</pl>
             <es>[EN] Living World</es>
@@ -793,7 +793,7 @@
             <uk>Випадкові світові події привносять динамічні та непередбачувані події на вашу ферму. 53 унікальні події у п'яти категоріях запускаються автоматично під час гри, впливаючи на економіку, техніку, поля, дику природу та багато іншого. Жодне проходження не буде схожим на попереднє.</uk>
             <da>Random World Events bringer dynamiske og uforudsigelige hændelser til din gård. 53 unikke hændelser fordelt på fem kategorier udløses automatisk under spillet og påvirker din økonomi, dine køretøjer, marker, dyreliv og meget mere. Hver gennemspilning føles unik.</da>
         
-            <de>[EN] Random World Events brings dynamic, unpredictable events to your farm. 53 unique events across five categories fire automatically during play, affecting your economy, vehicles, fields, wildlife, and more. No two playthroughs will feel the same.</de>
+            <de>Zufällige Welteregnisse bringen dynamische, unvorhersagbare Ereignisse auf deine Farm. 53 einzigartige Ereignisse aus fünf Kategorien starten zufällig im Spiel und beeinflussen Wirtschaft, Fahrzeuge, Wildtiere und mehr. Kein Spieldurchlauf wird sich mehr gleich anfühlen.</de>
             <fr>[EN] Random World Events brings dynamic, unpredictable events to your farm. 53 unique events across five categories fire automatically during play, affecting your economy, vehicles, fields, wildlife, and more. No two playthroughs will feel the same.</fr>
             <pl>[EN] Random World Events brings dynamic, unpredictable events to your farm. 53 unique events across five categories fire automatically during play, affecting your economy, vehicles, fields, wildlife, and more. No two playthroughs will feel the same.</pl>
             <es>[EN] Random World Events brings dynamic, unpredictable events to your farm. 53 unique events across five categories fire automatically during play, affecting your economy, vehicles, fields, wildlife, and more. No two playthroughs will feel the same.</es>
@@ -807,7 +807,7 @@
             <uk>Чого очікувати</uk>
             <da>Hvad kan du forvente</da>
         
-            <de>[EN] What to Expect</de>
+            <de>Was zu erwarten ist</de>
             <fr>[EN] What to Expect</fr>
             <pl>[EN] What to Expect</pl>
             <es>[EN] What to Expect</es>
@@ -821,7 +821,7 @@
             <uk>Події відображаються як сповіщення HUD і тривають налаштовуваний час. Деякі дають бонуси (підйоми на ринку, поповнення палива, підсилення врожаю), тоді як інші створюють труднощі (аварії, падіння цін, натовпи тварин). Таймер перерви запобігає надмірній кількості подій.</uk>
             <da>Hændelser vises som HUD-notifikationer og varer i et tidsrum, du selv kan konfigurere. Nogle giver bonusser (markedsboom, brændstofpåfyldning, afgrødebonusser), mens andre skaber udfordringer (ulykker, prisstyrt, paniske dyreflokke). En cooldown-timer sikrer, at hændelser ikke spammer spillet.</da>
         
-            <de>[EN] Events appear as HUD notifications and last for a configurable duration. Some grant bonuses (market booms, fuel refills, crop buffs), while others impose challenges (accidents, price crashes, stampedes). A cooldown timer prevents event spam.</de>
+            <de>Die Ereignisse starten mit einer HUD-Benachrichtigung und dauern für eine einstellbare Zeit an. Einige geben Boni (z.B. Marktnachfrage, Betankungen oder Erntebuffs), andere sorgen für Schwierigkeiten (z.B. Unfälle, Preiseinbrüche, wilde Tierherden). Eingebaute Timer verhindern, dass zu viele Ereignisse starten.</de>
             <fr>[EN] Events appear as HUD notifications and last for a configurable duration. Some grant bonuses (market booms, fuel refills, crop buffs), while others impose challenges (accidents, price crashes, stampedes). A cooldown timer prevents event spam.</fr>
             <pl>[EN] Events appear as HUD notifications and last for a configurable duration. Some grant bonuses (market booms, fuel refills, crop buffs), while others impose challenges (accidents, price crashes, stampedes). A cooldown timer prevents event spam.</pl>
             <es>[EN] Events appear as HUD notifications and last for a configurable duration. Some grant bonuses (market booms, fuel refills, crop buffs), while others impose challenges (accidents, price crashes, stampedes). A cooldown timer prevents event spam.</es>
@@ -837,7 +837,7 @@
             <uk>Як працюють події</uk>
             <da>Hvordan hændelser virker</da>
         
-            <de>[EN] How Events Work</de>
+            <de>Wie Ereignisse funktionieren</de>
             <fr>[EN] How Events Work</fr>
             <pl>[EN] How Events Work</pl>
             <es>[EN] How Events Work</es>
@@ -851,7 +851,7 @@
             <uk>Система запуску</uk>
             <da>Hændelsesudløser</da>
         
-            <de>[EN] Trigger System</de>
+            <de>Auslösung</de>
             <fr>[EN] Trigger System</fr>
             <pl>[EN] Trigger System</pl>
             <es>[EN] Trigger System</es>
@@ -865,7 +865,7 @@
             <uk>При кожному ігровому тику є невелика ймовірність запуску події, яка контролюється параметром «Частота» (1–10). Коли подія запускається, з усіх увімкнених категорій вибирається випадкова відповідна подія. Одночасно може бути активна лише одна подія.</uk>
             <da>Ved hvert game-tick er der en lille sandsynlighed for, at en hændelse udløses, styret af indstillingen Hyppighed (1–10). Når en hændelse aktiveres, vælges en tilfældig tilgængelig hændelse fra alle aktiverede kategorier. Kun én hændelse kan være aktiv ad gangen.</da>
         
-            <de>[EN] Each game tick there is a small probability of an event firing, controlled by the Frequency setting (1-10). When an event triggers, a random eligible event from all enabled categories is selected. Only one event can be active at a time.</de>
+            <de>Zu jedem Spielzeitpunkt ist es mit einer geringen Wahrscheinlichkeit möglich, ein Ereignis auszulösen - abhängig der  eingestellten Frequenz (1-10). Wenn ein Ereignis ausgelöst wird, so wird ein zufälliges Ereignis aus allen aktiven Kategorien gewählt. Es kann nur ein Ereignis aktiv sein.</de>
             <fr>[EN] Each game tick there is a small probability of an event firing, controlled by the Frequency setting (1-10). When an event triggers, a random eligible event from all enabled categories is selected. Only one event can be active at a time.</fr>
             <pl>[EN] Each game tick there is a small probability of an event firing, controlled by the Frequency setting (1-10). When an event triggers, a random eligible event from all enabled categories is selected. Only one event can be active at a time.</pl>
             <es>[EN] Each game tick there is a small probability of an event firing, controlled by the Frequency setting (1-10). When an event triggers, a random eligible event from all enabled categories is selected. Only one event can be active at a time.</es>
@@ -879,7 +879,7 @@
             <uk>Інтенсивність та перерва</uk>
             <da>Intensitet &amp; cooldown</da>
         
-            <de>[EN] Intensity &amp; Cooldown</de>
+            <de>Intensität &amp; Cooldown</de>
             <fr>[EN] Intensity &amp; Cooldown</fr>
             <pl>[EN] Intensity &amp; Cooldown</pl>
             <es>[EN] Intensity &amp; Cooldown</es>
@@ -893,7 +893,7 @@
             <uk>Інтенсивність (1–5) визначає силу ефектів — підйом ринку рівня 5 дає більший бонус, ніж рівень 1. Після кожної події має пройти час перерви (1–240 хвилин), перш ніж може статися наступна подія. Обидва параметри налаштовуються для кожного збереження.</uk>
             <da>Intensitet (1–5) skalerer styrken af effekterne — et markedsboom på niveau 5 giver en større bonus end niveau 1. Efter hver hændelse skal en cooldown-periode (1–240 minutter) passere, før den næste hændelse kan udløses. Begge indstillinger kan konfigureres separat for hvert savegame.</da>
         
-            <de>[EN] Intensity (1-5) scales the strength of effects — a level 5 market boom gives a bigger bonus than level 1. After each event, a cooldown period (1-240 minutes) must pass before the next event can fire. Both settings are configurable per savegame.</de>
+            <de>Intensität (1-5) skaliert die Effektstärke - ein Level 5 Marktboom gibt einen größeren Bonus als Level 1. Nach jedem Ereignis muss ein Cooldown abgewartet werden (1-240 Minuten), bevor ein neues Ereignis ausgelöst werden kann. Beide Einstellungen sind im Savegame konfigurierbar.</de>
             <fr>[EN] Intensity (1-5) scales the strength of effects — a level 5 market boom gives a bigger bonus than level 1. After each event, a cooldown period (1-240 minutes) must pass before the next event can fire. Both settings are configurable per savegame.</fr>
             <pl>[EN] Intensity (1-5) scales the strength of effects — a level 5 market boom gives a bigger bonus than level 1. After each event, a cooldown period (1-240 minutes) must pass before the next event can fire. Both settings are configurable per savegame.</pl>
             <es>[EN] Intensity (1-5) scales the strength of effects — a level 5 market boom gives a bigger bonus than level 1. After each event, a cooldown period (1-240 minutes) must pass before the next event can fire. Both settings are configurable per savegame.</es>
@@ -909,7 +909,7 @@
             <uk>Економічні події</uk>
             <da>Økonomiske hændelser</da>
         
-            <de>[EN] Economic Events</de>
+            <de>Wirtschaftsereignisse</de>
             <fr>[EN] Economic Events</fr>
             <pl>[EN] Economic Events</pl>
             <es>[EN] Economic Events</es>
@@ -923,7 +923,7 @@
             <uk>Позитивні події (11)</uk>
             <da>Positive hændelser (11)</da>
         
-            <de>[EN] Positive Events (11)</de>
+            <de>11 positive Ereignisse</de>
             <fr>[EN] Positive Events (11)</fr>
             <pl>[EN] Positive Events (11)</pl>
             <es>[EN] Positive Events (11)</es>
@@ -937,7 +937,7 @@
             <uk>Державні субсидії, підйоми на ринку, пожертви фермерів, повернення податків, страхові виплати, експортні можливості, знижки на насіння, знижки на добрива, знижки на паливо, знижки на обладнання та цінові бонуси (тимчасово підвищені ціни продажу). Ці події надають пряму готівку або тимчасові цінові бонуси.</uk>
             <da>Statslige tilskud, markedsboom, donationer fra landmænd, skatterefusioner, forsikringsudbetalinger, eksportmuligheder, rabatter på frø, rabatter på gødning, rabatter på brændstof, rabatter på udstyr samt bonusser fra prisfastsættelse (midlertidigt forhøjede salgspriser). Disse hændelser giver direkte kontanter eller midlertidige prisbonusser.</da>
         
-            <de>[EN] Government subsidies, market booms, farmer donations, tax refunds, insurance payouts, export opportunities, seed discounts, fertilizer discounts, fuel discounts, equipment discounts, and price-fixing bonuses (temporary elevated sell prices). These events grant direct cash or temporary price bonuses.</de>
+            <de>Staatliche Subventionen, Marktbooms, Spenden von Landwirten, Steuerrückerstattungen, Versicherungsleistungen, Exportmöglichkeiten, Saatgut-, Düngemittel-, Kraftstoff- und Geräterabatte sowie Preisbindungsprämien (vorübergehend erhöhte Verkaufspreise) können zu direkten Geldauszahlungen oder befristeten Preisboni führen.</de>
             <fr>[EN] Government subsidies, market booms, farmer donations, tax refunds, insurance payouts, export opportunities, seed discounts, fertilizer discounts, fuel discounts, equipment discounts, and price-fixing bonuses (temporary elevated sell prices). These events grant direct cash or temporary price bonuses.</fr>
             <pl>[EN] Government subsidies, market booms, farmer donations, tax refunds, insurance payouts, export opportunities, seed discounts, fertilizer discounts, fuel discounts, equipment discounts, and price-fixing bonuses (temporary elevated sell prices). These events grant direct cash or temporary price bonuses.</pl>
             <es>[EN] Government subsidies, market booms, farmer donations, tax refunds, insurance payouts, export opportunities, seed discounts, fertilizer discounts, fuel discounts, equipment discounts, and price-fixing bonuses (temporary elevated sell prices). These events grant direct cash or temporary price bonuses.</es>
@@ -951,7 +951,7 @@
             <uk>Негативні події (4)</uk>
             <da>Negative hændelser (4)</da>
         
-            <de>[EN] Negative Events (4)</de>
+            <de>4 negative Ereignisse</de>
             <fr>[EN] Negative Events (4)</fr>
             <pl>[EN] Negative Events (4)</pl>
             <es>[EN] Negative Events (4)</es>
@@ -965,7 +965,7 @@
             <uk>Обвали ринку (знижені ціни продажу), раптові витрати (миттєва втрата грошей), нарахування відсотків за кредитом (відсоток від наявних коштів) та економічні кризи (поєднання ринкових штрафів і поточних витрат за кредитом). Кризи високої інтенсивності накопичують обидва ефекти. Вимкніть категорію «Економіка», щоб відключити все це.</uk>
             <da>Markedsnedbrud (reducerede salgspriser), uforudsete udgifter (øjeblikkeligt pengetab), lånerenter (en procentdel af din nuværende saldo) og økonomiske kriser (kombineret markedstraf plus løbende låneomkostninger). Kriser med høj intensitet kombinerer begge effekter. Slå kategorien Økonomi fra for at deaktivere dem alle.</da>
         
-            <de>[EN] Market crashes (reduced sell prices), sudden expenses (immediate cash loss), loan interest charges (percentage of current money), and economic crises (combined market penalty plus ongoing loan costs). High-intensity crises stack both effects. Toggle the Economic category off to disable all of these.</de>
+            <de>Markteinbrüche (sinkende Verkaufspreise), plötzliche Ausgaben (sofortiger Geldverlust), Kreditzinsen (Prozentsatz des aktuellen Geldbetrags) und Wirtschaftskrisen (Kombination aus Markteinbußen und laufenden Kreditkosten) verstärken diese Effekte. Schwere Krisen addieren beide Effekte. Deaktivieren der Kategtegorie Wirtschaft schalte all diese Effekte aus.</de>
             <fr>[EN] Market crashes (reduced sell prices), sudden expenses (immediate cash loss), loan interest charges (percentage of current money), and economic crises (combined market penalty plus ongoing loan costs). High-intensity crises stack both effects. Toggle the Economic category off to disable all of these.</fr>
             <pl>[EN] Market crashes (reduced sell prices), sudden expenses (immediate cash loss), loan interest charges (percentage of current money), and economic crises (combined market penalty plus ongoing loan costs). High-intensity crises stack both effects. Toggle the Economic category off to disable all of these.</pl>
             <es>[EN] Market crashes (reduced sell prices), sudden expenses (immediate cash loss), loan interest charges (percentage of current money), and economic crises (combined market penalty plus ongoing loan costs). High-intensity crises stack both effects. Toggle the Economic category off to disable all of these.</es>
@@ -981,7 +981,7 @@
             <uk>Події з технікою та полями</uk>
             <da>Køretøjs- &amp; markhændelser</da>
         
-            <de>[EN] Vehicle &amp; Field Events</de>
+            <de>Fahrzeug- &amp; Feldereignisse</de>
             <fr>[EN] Vehicle &amp; Field Events</fr>
             <pl>[EN] Vehicle &amp; Field Events</pl>
             <es>[EN] Vehicle &amp; Field Events</es>
@@ -995,7 +995,7 @@
             <uk>Події з технікою (8)</uk>
             <da>Køretøjshændelser (8)</da>
         
-            <de>[EN] Vehicle Events (8)</de>
+            <de>8 Fahrzeugereignisse</de>
             <fr>[EN] Vehicle Events (8)</fr>
             <pl>[EN] Vehicle Events (8)</pl>
             <es>[EN] Vehicle Events (8)</es>
@@ -1009,7 +1009,7 @@
             <uk>Прискорення, безкоштовне поповнення палива, витік палива, дрібні аварії з рахунками за ремонт, повне чищення парку техніки, візуальні оновлення, проблеми з двигуном (знижена потужність) та екстрені рахунки за ремонт. Більшість подій з технікою стосуються транспортного засобу, яким ви керуєте.</uk>
             <da>Hastighedsboosts, gratis brændstofpåfyldninger, brændstoflækager, mindre ulykker med reparationsregninger, rengøring af hele køretøjsflåden, visuelle opgraderinger, motorproblemer (reduceret kraft) samt akutte reparationsregninger. De fleste køretøjshændelser påvirker det køretøj, du aktuelt styrer.</da>
         
-            <de>[EN] Speed boosts, free fuel refills, fuel leaks, minor accidents with repair bills, full fleet cleaning, visual upgrades, engine trouble (reduced power), and emergency repair bills. Most vehicle events target your currently controlled vehicle.</de>
+            <de>Höhere Geschwindigkeiten, kostenlose Tankfüllungen, Kraftstofflecks, kleinere Unfälle mit Reparaturkosten, Komplettreinigung der Flotte, kostenlose Lackierungen, Motorprobleme (Leistungsverlust) und Rechnungen für Notfallreparaturen. Die meisten Fahrzeugereignisse betreffen das aktuell gesteuerte Fahrzeug.</de>
             <fr>[EN] Speed boosts, free fuel refills, fuel leaks, minor accidents with repair bills, full fleet cleaning, visual upgrades, engine trouble (reduced power), and emergency repair bills. Most vehicle events target your currently controlled vehicle.</fr>
             <pl>[EN] Speed boosts, free fuel refills, fuel leaks, minor accidents with repair bills, full fleet cleaning, visual upgrades, engine trouble (reduced power), and emergency repair bills. Most vehicle events target your currently controlled vehicle.</pl>
             <es>[EN] Speed boosts, free fuel refills, fuel leaks, minor accidents with repair bills, full fleet cleaning, visual upgrades, engine trouble (reduced power), and emergency repair bills. Most vehicle events target your currently controlled vehicle.</es>
@@ -1023,7 +1023,7 @@
             <uk>Події на полях (10)</uk>
             <da>Markhændelser (10)</da>
         
-            <de>[EN] Field Events (10)</de>
+            <de>10 Feldereignisse</de>
             <fr>[EN] Field Events (10)</fr>
             <pl>[EN] Field Events (10)</pl>
             <es>[EN] Field Events (10)</es>
@@ -1037,7 +1037,7 @@
             <uk>Бонуси та штрафи до врожайності культур, подвоєна або вдвічі знижена ефективність добрив, зміни швидкості росту насіння, модифікатори кількості врожаю та зміни цін продажу з поля. Для подій на полях потрібне хоча б одне поле на карті.</uk>
             <da>Bonusser og straf på afgrødeudbytte, fordoblet eller halveret effektivitet af gødning, ændringer i frøenes væksthastighed, modifikatorer for høstmængde samt ændringer i markens salgspris. Markhændelser kræver, at der er mindst én mark på kortet for at kunne udløses.</da>
         
-            <de>[EN] Crop yield bonuses and penalties, doubled or halved fertilizer effectiveness, seed growth speed changes, harvest amount modifiers, and field sale price shifts. Field events require at least one field on the map to be eligible.</de>
+            <de>Ernteertragsboni und -mali, verdoppelte oder halbierte Düngemittelwirkung, Änderungen der Wachstumsgeschwindigkeit, Modifikationen der Erntemenge und Änderungen der Feldverkaufspreise. Feldereignisse erfordern mindestens ein Feld auf der Karte, um ausgelöst zu werden.</de>
             <fr>[EN] Crop yield bonuses and penalties, doubled or halved fertilizer effectiveness, seed growth speed changes, harvest amount modifiers, and field sale price shifts. Field events require at least one field on the map to be eligible.</fr>
             <pl>[EN] Crop yield bonuses and penalties, doubled or halved fertilizer effectiveness, seed growth speed changes, harvest amount modifiers, and field sale price shifts. Field events require at least one field on the map to be eligible.</pl>
             <es>[EN] Crop yield bonuses and penalties, doubled or halved fertilizer effectiveness, seed growth speed changes, harvest amount modifiers, and field sale price shifts. Field events require at least one field on the map to be eligible.</es>
@@ -1053,7 +1053,7 @@
             <uk>Особливі події та події з дикою природою</uk>
             <da>Særlige &amp; dyrelivshændelser</da>
         
-            <de>[EN] Special &amp; Wildlife Events</de>
+            <de>Spezial- &amp; Wildtierereignisse</de>
             <fr>[EN] Special &amp; Wildlife Events</fr>
             <pl>[EN] Special &amp; Wildlife Events</pl>
             <es>[EN] Special &amp; Wildlife Events</es>
@@ -1067,7 +1067,7 @@
             <uk>Особливі події (10)</uk>
             <da>Særlige hændelser (10)</da>
         
-            <de>[EN] Special Events (10)</de>
+            <de>10 Spezialereignisse</de>
             <fr>[EN] Special Events (10)</fr>
             <pl>[EN] Special Events (10)</pl>
             <es>[EN] Special Events (10)</es>
@@ -1081,7 +1081,7 @@
             <uk>Прискорення та уповільнення часу (впливає на масштаб ігрового часу), бонуси та штрафи до отримання досвіду, множники грошей, зміни міцності обладнання, кращі торгові ціни та міські фестивалі. Після закінчення часових подій відновлюється початковий масштаб часу.</uk>
             <da>Tidsacceleration og -opbremsning (påvirker spillets tidsskala), bonusser og straf på XP-optjening, pengemultiplikatorer, ændringer i udstyrets holdbarhed, bedre handelspriser samt byfestivaler. Tidsrelaterede hændelser gendanner den oprindelige tidsskala, når de slutter.</da>
         
-            <de>[EN] Time acceleration and slowdown (affects in-game time scale), XP gain bonuses and penalties, money multipliers, equipment durability changes, better trade prices, and town festivals. Time events restore the original time scale when they end.</de>
+            <de>Zeitbeschleunigung und -verlangsamung (beeinflusst die Spielzeit), Boni und Mali beim EP-Gewinn, Geldmultiplikatoren, Änderungen der Ausrüstungshaltbarkeit, bessere Handelspreise und Stadtfeste. Zeitereignisse stellen nach ihrem Ende die ursprüngliche Zeit wieder her.</de>
             <fr>[EN] Time acceleration and slowdown (affects in-game time scale), XP gain bonuses and penalties, money multipliers, equipment durability changes, better trade prices, and town festivals. Time events restore the original time scale when they end.</fr>
             <pl>[EN] Time acceleration and slowdown (affects in-game time scale), XP gain bonuses and penalties, money multipliers, equipment durability changes, better trade prices, and town festivals. Time events restore the original time scale when they end.</pl>
             <es>[EN] Time acceleration and slowdown (affects in-game time scale), XP gain bonuses and penalties, money multipliers, equipment durability changes, better trade prices, and town festivals. Time events restore the original time scale when they end.</es>
@@ -1095,7 +1095,7 @@
             <uk>Події з дикою природою (10)</uk>
             <da>Dyrelivshændelser (10)</da>
         
-            <de>[EN] Wildlife Events (10)</de>
+            <de>10 Wildtierereignisse</de>
             <fr>[EN] Wildlife Events (10)</fr>
             <pl>[EN] Wildlife Events (10)</pl>
             <es>[EN] Wildlife Events (10)</es>
@@ -1109,7 +1109,7 @@
             <uk>Зграї птахів, корисні комахи, дикі натовпи тварин, сповіщення про хижаків, нашестя кролів, рої бджіл, бонуси сезону полювання, бонуси та штрафи до продуктів тваринництва, ветеринарні рахунки та спалахи хвороб. Увімкніть категорію «Дика природа», щоб переживати ці події.</uk>
             <da>Fugleflokke, nyttige insekter, vilde dyreflokke på flugt, rovdyrvarsler, kaninangreb, bisværme, bonusser i jagtsæsonen, bonusser og straf på husdyrprodukter, dyrlægeregninger samt sygdomsbekymringer. Aktivér kategorien Dyreliv for at opleve disse hændelser.</da>
         
-            <de>[EN] Bird flocks, beneficial insects, wild stampedes, predator alerts, rabbit infestations, bee swarms, hunting season bonuses, livestock product bonuses and penalties, veterinary bills, and disease scares. Enable the Wildlife category to experience these.</de>
+            <de>Vogelschwärme, nützliche Insekten, wilde Tierherden, Raubtierwarnungen, Kaninchenplagen, Bienenschwärme, Boni in der Jagdsaison, Boni und Mali bei der Viehprodukten, Tierarztkosten und Seuchenwarnungen. Diese Ereignisse sind nur aktiv, wenn die Einstellung Wildtiere aktiv ist.</de>
             <fr>[EN] Bird flocks, beneficial insects, wild stampedes, predator alerts, rabbit infestations, bee swarms, hunting season bonuses, livestock product bonuses and penalties, veterinary bills, and disease scares. Enable the Wildlife category to experience these.</fr>
             <pl>[EN] Bird flocks, beneficial insects, wild stampedes, predator alerts, rabbit infestations, bee swarms, hunting season bonuses, livestock product bonuses and penalties, veterinary bills, and disease scares. Enable the Wildlife category to experience these.</pl>
             <es>[EN] Bird flocks, beneficial insects, wild stampedes, predator alerts, rabbit infestations, bee swarms, hunting season bonuses, livestock product bonuses and penalties, veterinary bills, and disease scares. Enable the Wildlife category to experience these.</es>
@@ -1125,7 +1125,7 @@
             <uk>Налаштування подій</uk>
             <da>Hændelsesindstillinger</da>
         
-            <de>[EN] Event Settings</de>
+            <de>Ereigniseinstellungen</de>
             <fr>[EN] Event Settings</fr>
             <pl>[EN] Event Settings</pl>
             <es>[EN] Event Settings</es>
@@ -1139,7 +1139,7 @@
             <uk>Частота (1–10)</uk>
             <da>Frekvens (1–10)</da>
         
-            <de>[EN] Frequency (1-10)</de>
+            <de>Häufigkeit (1-10)</de>
             <fr>[EN] Frequency (1-10)</fr>
             <pl>[EN] Frequency (1-10)</pl>
             <es>[EN] Frequency (1-10)</es>
@@ -1153,7 +1153,7 @@
             <uk>Контролює, як часто відбуваються події. Вищі значення збільшують ймовірність запуску за кожен тік. Частота 10 означає, що події відбуваються майже в кожен період перерви, тоді як 1 робить їх дуже рідкісними. За замовчуванням встановлено 5 для збалансованого ігрового процесу.</uk>
             <da>Styrer, hvor ofte hændelser udløses. Højere værdier øger sandsynligheden for udløsning ved hvert tick. En hyppighed på 10 betyder, at hændelser udløses næsten ved hver cooldown-periode, mens 1 gør dem meget sjældne. Standardværdien er 5 for en afbalanceret oplevelse.</da>
         
-            <de>[EN] Controls how often events fire. Higher values increase the per-tick trigger probability. A frequency of 10 means events fire nearly every cooldown period, while 1 makes them very rare. Default is 5 for a balanced experience.</de>
+            <de>Steuert, wie oft Ereignisse eintreten. Höhere Werte steigern die Wahrscheinlichkeit. Eine Häufigkeit von 10 bedeutet, dass ein neues Ereignis nahezu immer nach dem Cooldown startet, während 1 Ereignisse sehr selten machen. Der Standard (5) ist für ein ausgewogenes Verhältnis.</de>
             <fr>[EN] Controls how often events fire. Higher values increase the per-tick trigger probability. A frequency of 10 means events fire nearly every cooldown period, while 1 makes them very rare. Default is 5 for a balanced experience.</fr>
             <pl>[EN] Controls how often events fire. Higher values increase the per-tick trigger probability. A frequency of 10 means events fire nearly every cooldown period, while 1 makes them very rare. Default is 5 for a balanced experience.</pl>
             <es>[EN] Controls how often events fire. Higher values increase the per-tick trigger probability. A frequency of 10 means events fire nearly every cooldown period, while 1 makes them very rare. Default is 5 for a balanced experience.</es>
@@ -1167,7 +1167,7 @@
             <uk>Інтенсивність (1–5) та перерва (1–240 хв)</uk>
             <da>Intensitet (1–5) &amp; cooldown (1–240 min.)</da>
         
-            <de>[EN] Intensity (1-5) &amp; Cooldown (1-240 min)</de>
+            <de>Intensität (1-5) &amp; Cooldown (1-240 min)</de>
             <fr>[EN] Intensity (1-5) &amp; Cooldown (1-240 min)</fr>
             <pl>[EN] Intensity (1-5) &amp; Cooldown (1-240 min)</pl>
             <es>[EN] Intensity (1-5) &amp; Cooldown (1-240 min)</es>
@@ -1181,7 +1181,7 @@
             <uk>Інтенсивність визначає масштаб ефектів подій — використовуйте нижчі значення для спокійного ігрового процесу, а вищі — для драматичних змін. Перерва встановлює мінімальний ігровий час між подіями. Збільшіть перерву для спокійнішого і менш частого ігрового процесу.</uk>
             <da>Intensitet skalerer styrken af hændelsernes effekter — brug lavere værdier for en mere rolig oplevelse og højere værdier for mere dramatiske udsving. Ventetid angiver det minimale antal minutter i spillet mellem hændelser. Øg ventetiden for en roligere oplevelse med færre hændelser.</da>
         
-            <de>[EN] Intensity scales the magnitude of event effects — use lower values for a gentle experience and higher values for dramatic swings. Cooldown sets the minimum in-game minutes between events. Increase cooldown for a calmer, less frequent experience.</de>
+            <de>Die Intensität skaliert die Stärke der Ereigniseffekte - kleinere Werte sorgen für ein harmonisches Erlebnis, größere Werte sorgen für stärkere Überraschungen. Der Cooldown setzt den Mindestwert in Ingame-Minuten zwischen den Ereignissen. Ein höherer Cooldown sorgt für ein ruhigeres Erlebnis mit weniger Ereignissen.</de>
             <fr>[EN] Intensity scales the magnitude of event effects — use lower values for a gentle experience and higher values for dramatic swings. Cooldown sets the minimum in-game minutes between events. Increase cooldown for a calmer, less frequent experience.</fr>
             <pl>[EN] Intensity scales the magnitude of event effects — use lower values for a gentle experience and higher values for dramatic swings. Cooldown sets the minimum in-game minutes between events. Increase cooldown for a calmer, less frequent experience.</pl>
             <es>[EN] Intensity scales the magnitude of event effects — use lower values for a gentle experience and higher values for dramatic swings. Cooldown sets the minimum in-game minutes between events. Increase cooldown for a calmer, less frequent experience.</es>
@@ -1197,7 +1197,7 @@
             <uk>Налаштування фізики</uk>
             <da>Fysiske indstillinger</da>
         
-            <de>[EN] Physics Settings</de>
+            <de>Spielphysik-Einstellungen</de>
             <fr>[EN] Physics Settings</fr>
             <pl>[EN] Physics Settings</pl>
             <es>[EN] Physics Settings</es>
@@ -1211,7 +1211,7 @@
             <uk>Зчеплення коліс та підвіска</uk>
             <da>Hjulgreb &amp; affjedring</da>
         
-            <de>[EN] Wheel Grip &amp; Suspension</de>
+            <de>Radschlupf &amp; Federung</de>
             <fr>[EN] Wheel Grip &amp; Suspension</fr>
             <pl>[EN] Wheel Grip &amp; Suspension</pl>
             <es>[EN] Wheel Grip &amp; Suspension</es>
@@ -1225,7 +1225,7 @@
             <uk>Система фізики застосовує зчеплення коліс залежно від типу поверхні для вашого транспортного засобу щокадру. Асфальт дає 110% зчеплення, бруд — 95%, поля — 85%, трава — 90%, сніг — 70%. Множник зчеплення коліс масштабує всі ці значення. Жорсткість підвіски множить силу пружини.</uk>
             <da>Fysiksystemet anvender terræntilpasset hjulfriktion på det køretøj, du styrer, i hver frame. Asfalt giver 110 % greb, jord 95 %, marker 85 %, græs 90 % og sne 70 %. Multiplikatoren for hjulgreb skalerer alle disse værdier. Affjedringsstivhed multiplicerer fjederkraften.</da>
         
-            <de>[EN] The physics system applies terrain-aware wheel friction to your controlled vehicle every frame. Asphalt gives 110% grip, dirt 95%, fields 85%, grass 90%, and snow 70%. The Wheel Grip Multiplier scales all of these values. Suspension Stiffness multiplies spring force.</de>
+            <de>Das Physiksystem wendet in jedem Frame eine geländeabhängige Radreibung auf Ihr gesteuertes Fahrzeug an. Asphalt bietet 110 % Grip, Schotter 95 %, Wiesen 85 %, Gras 90 % und Schnee 70 %. Der Radgrip-Multiplikator skaliert all diese Werte. Die Federungssteifigkeit multipliziert die Federkraft.</de>
             <fr>[EN] The physics system applies terrain-aware wheel friction to your controlled vehicle every frame. Asphalt gives 110% grip, dirt 95%, fields 85%, grass 90%, and snow 70%. The Wheel Grip Multiplier scales all of these values. Suspension Stiffness multiplies spring force.</fr>
             <pl>[EN] The physics system applies terrain-aware wheel friction to your controlled vehicle every frame. Asphalt gives 110% grip, dirt 95%, fields 85%, grass 90%, and snow 70%. The Wheel Grip Multiplier scales all of these values. Suspension Stiffness multiplies spring force.</pl>
             <es>[EN] The physics system applies terrain-aware wheel friction to your controlled vehicle every frame. Asphalt gives 110% grip, dirt 95%, fields 85%, grass 90%, and snow 70%. The Wheel Grip Multiplier scales all of these values. Suspension Stiffness multiplies spring force.</es>
@@ -1239,7 +1239,7 @@
             <uk>Налагодження та інформація про фізику</uk>
             <da>Fejlfinding &amp; Fysisk info</da>
         
-            <de>[EN] Debug &amp; Physics Info</de>
+            <de>Debug &amp; Physikinfo</de>
             <fr>[EN] Debug &amp; Physics Info</fr>
             <pl>[EN] Debug &amp; Physics Info</pl>
             <es>[EN] Debug &amp; Physics Info</es>
@@ -1253,7 +1253,7 @@
             <uk>Увімкніть «Показати інформацію про фізику», щоб записувати дані швидкості та множника для кожного транспортного засобу щокадру. Увімкніть режим налагодження для перегляду значень зчеплення кожного колеса. Це корисно для налаштування параметрів фізики, але може призвести до детального виводу в консоль під час звичайної гри.</uk>
             <da>Aktivér Vis fysikinfo for at logge hastigheds- og multiplikatordata pr. køretøj i hver frame. Aktivér Debugtilstand for grebsværdier pr. hjul. Disse er nyttige til finjustering af dine fysikindstillinger, men kan give meget detaljeret konsoloutput under normal spilbrug.</da>
         
-            <de>[EN] Enable Show Physics Info to log per-vehicle speed and multiplier data each frame. Enable Debug Mode for per-wheel grip values. These are useful for tuning your physics settings but may produce verbose console output during normal play.</de>
+            <de>Aktivieren Sie die Physikinfo-Anzeige, um Geschwindigkeits- und Multiplikatordaten für jedes Fahrzeug in jedem Frame zu protokollieren. Aktivieren Sie den Debug-Modus für die Haftungswerte jedes einzelnen Rades. Diese Einstellungen sind nützlich, um die Physik-Einstellungen anzupassen, können aber während des normalen Spielverlaufs zu ausführlichen Konsolenausgaben führen.</de>
             <fr>[EN] Enable Show Physics Info to log per-vehicle speed and multiplier data each frame. Enable Debug Mode for per-wheel grip values. These are useful for tuning your physics settings but may produce verbose console output during normal play.</fr>
             <pl>[EN] Enable Show Physics Info to log per-vehicle speed and multiplier data each frame. Enable Debug Mode for per-wheel grip values. These are useful for tuning your physics settings but may produce verbose console output during normal play.</pl>
             <es>[EN] Enable Show Physics Info to log per-vehicle speed and multiplier data each frame. Enable Debug Mode for per-wheel grip values. These are useful for tuning your physics settings but may produce verbose console output during normal play.</es>
@@ -1269,7 +1269,7 @@
             <uk>Керування та консольні команди</uk>
             <da>Styring &amp; kommandoer</da>
         
-            <de>[EN] Controls &amp; Console Commands</de>
+            <de>Tastatur- &amp; Konsolenbefehle</de>
             <fr>[EN] Controls &amp; Console Commands</fr>
             <pl>[EN] Controls &amp; Console Commands</pl>
             <es>[EN] Controls &amp; Console Commands</es>
@@ -1283,7 +1283,7 @@
             <uk>Гарячі клавіші</uk>
             <da>Genvejstaster</da>
         
-            <de>[EN] Keyboard Shortcuts</de>
+            <de>Tastatur-Eingaben</de>
             <fr>[EN] Keyboard Shortcuts</fr>
             <pl>[EN] Keyboard Shortcuts</pl>
             <es>[EN] Keyboard Shortcuts</es>
@@ -1297,7 +1297,7 @@
             <uk>F3: Відкрити екран налаштувань випадкових світових подій. F9: Негайно примусово запустити випадкову подію (корисно для тестування). Ці прив'язки можна змінити в меню прив'язок клавіш гри в розділі «Випадкові світові події».</uk>
             <da>F3: Åbn indstillingsskærmen for Random World Events. F9: Tving straks en tilfældig hændelse til at udløses (nyttigt til test). Disse tastetildelinger kan ændres i spillets menu for tastetildelinger under sektionen Random World Events.</da>
         
-            <de>[EN] F3: Open the Random World Events settings screen. F9: Immediately force-trigger a random event (useful for testing). These bindings can be changed in the game's keybinding menu under the Random World Events section.</de>
+            <de>F3: Öffnet den Einstellungsbildschirm von zufällige Weltereignisse. F9: Sofort ein zufälliges Ereignis auslösen (nützlich zum Testen). Alle Belegungen können in den Spieleinstellungen unter dem Abschnitt zufällige Weltereignisse angepasst werden.</de>
             <fr>[EN] F3: Open the Random World Events settings screen. F9: Immediately force-trigger a random event (useful for testing). These bindings can be changed in the game's keybinding menu under the Random World Events section.</fr>
             <pl>[EN] F3: Open the Random World Events settings screen. F9: Immediately force-trigger a random event (useful for testing). These bindings can be changed in the game's keybinding menu under the Random World Events section.</pl>
             <es>[EN] F3: Open the Random World Events settings screen. F9: Immediately force-trigger a random event (useful for testing). These bindings can be changed in the game's keybinding menu under the Random World Events section.</es>
@@ -1311,7 +1311,7 @@
             <uk>Консольні команди</uk>
             <da>Kommandoer</da>
         
-            <de>[EN] Console Commands</de>
+            <de>Konsolenbefehle</de>
             <fr>[EN] Console Commands</fr>
             <pl>[EN] Console Commands</pl>
             <es>[EN] Console Commands</es>
@@ -1325,7 +1325,7 @@
             <uk>Відкрийте консоль розробника та введіть: rwe (допомога), rweStatus (поточний стан), rweTest (примусовий запуск), rweEnd (зупинити активну подію), rweSettings (відкрити інтерфейс), rweDebug on|off (перемкнути детальне журналювання), rweList [категорія] (список усіх подій).</uk>
             <da>Åbn udviklerkonsollen og skriv: rwe (hjælp), rweStatus (nuværende status), rweTest (tving en hændelse til at udløses), rweEnd (stop aktiv hændelse), rweSettings (åbn GUI), rweDebug on|off (slå detaljeret logning til/fra), rweList [kategori] (vis alle hændelser).</da>
         
-            <de>[EN] Open the developer console and type: rwe (help), rweStatus (current state), rweTest (force trigger), rweEnd (stop active event), rweSettings (open GUI), rweDebug on|off (toggle verbose logging), rweList [category] (list all events).</de>
+            <de>In der geöffneten Entwicklerkonsole (Standard: ^): rwe (Hilfe), rweStatus (Aktueller Status), rweTest (sofortiges Ereignis), rweEnd (aktives Ereignis stoppen), rweSettings (Einstellungsbildschirm öffnen), rweDebug on|off (ausführliches Loggen (de)aktivieren), rweList [category] (Alle Ereignisse auflisten).</de>
             <fr>[EN] Open the developer console and type: rwe (help), rweStatus (current state), rweTest (force trigger), rweEnd (stop active event), rweSettings (open GUI), rweDebug on|off (toggle verbose logging), rweList [category] (list all events).</fr>
             <pl>[EN] Open the developer console and type: rwe (help), rweStatus (current state), rweTest (force trigger), rweEnd (stop active event), rweSettings (open GUI), rweDebug on|off (toggle verbose logging), rweList [category] (list all events).</pl>
             <es>[EN] Open the developer console and type: rwe (help), rweStatus (current state), rweTest (force trigger), rweEnd (stop active event), rweSettings (open GUI), rweDebug on|off (toggle verbose logging), rweList [category] (list all events).</es>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -14,6 +14,7 @@
         <br>Eventos Mundiais Aleatórios</br>
         <uk>Випадкові світові події</uk>
         <ru>Случайные мировые события</ru>
+        <da>Random World Events</da>
     </title>
     <description>
         <en>Adds random events, physics overhaul, and configurable settings.</en>
@@ -26,6 +27,7 @@
         <br>Adiciona eventos aleatórios, revisão de física e configurações personalizáveis.</br>
         <uk>Додає випадкові події, переробку фізики та настроювані параметри.</uk>
         <ru>Добавляет случайные события, переработку физики и настраиваемые параметры.</ru>
+        <da>Tilføjer tilfældige hændelser, fysikopdateringer og konfigurerbare indstillinger.</da>
     </description>
     <iconFilename>icon.dds</iconFilename>
 
@@ -81,6 +83,7 @@
             <br>Eventos Mundiais Aleatórios</br>
             <uk>Випадкові світові події</uk>
             <ru>Случайные мировые события</ru>
+            <da>Random World Events</da>
         </text>
 
         <text name="rwe_events_enabled_short">
@@ -94,6 +97,7 @@
             <br>Ativar eventos</br>
             <uk>Увімкнути події</uk>
             <ru>Включить события</ru>
+            <da>Aktiver hændelser</da>
         </text>
 
         <text name="rwe_events_enabled_long">
@@ -107,180 +111,221 @@
             <br>Ativar ou desativar todos os eventos aleatórios</br>
             <uk>Увімкнути або вимкнути всі випадкові події</uk>
             <ru>Включить или выключить все случайные события</ru>
+            <da>Aktivér eller deaktivér alle tilfældige hændelser</da>
         </text>
 
         <!-- Subsection headers -->
         <text name="rwe_subheader_timing">
             <en>Event Timing</en>
             <uk>Розклад подій</uk>
+            <da>Interval for hændelser</da>
         </text>
         <text name="rwe_subheader_hud">
             <en>Notifications &amp; HUD</en>
             <uk>Сповіщення та HUD</uk>
+            <da>Notifikationer &amp; HUD</da>
         </text>
         <text name="rwe_subheader_categories">
             <en>Event Categories</en>
             <uk>Категорії подій</uk>
+            <da>Hændelsestyper</da>
         </text>
         <text name="rwe_subheader_physics">
             <en>Physics Override</en>
             <uk>Налаштування фізики</uk>
+            <da>Fysikoverstyring</da>
         </text>
         <text name="rwe_subheader_debug">
             <en>Debug</en>
             <uk>Налагодження</uk>
+            <da>Fejlfinding</da>
         </text>
 
         <!-- Timing -->
         <text name="rwe_frequency_short">
             <en>Frequency</en>
             <uk>Частота</uk>
+            <da>Frekvens</da>
         </text>
         <text name="rwe_frequency_long">
             <en>How often events fire (1 = rare, 10 = frequent)</en>
             <uk>Як часто виникають події (1 = рідко, 10 = часто)</uk>
+            <da>Hvor ofte hændelser udløses (1 = sjældent, 10 = ofte)</da>
         </text>
         <text name="rwe_intensity_short">
             <en>Intensity</en>
             <uk>Інтенсивність</uk>
+            <da>Styrke</da>
         </text>
         <text name="rwe_intensity_long">
             <en>Strength of event effects (1 = mild, 5 = extreme)</en>
             <uk>Сила ефектів подій (1 = слабка, 5 = екстремальна)</uk>
+            <da>Styrken af hændelseseffekter (1 = mild, 5 = ekstrem)</da>
         </text>
         <text name="rwe_cooldown_short">
             <en>Cooldown</en>
             <uk>Перерва</uk>
+            <da>Cooldown</da>
         </text>
         <text name="rwe_cooldown_long">
             <en>Minimum in-game time between events</en>
             <uk>Мінімальний ігровий час між подіями</uk>
+            <da>Minimum in-game tid mellem hændelser</da>
         </text>
 
         <!-- Notifications and HUD -->
         <text name="rwe_notifications_short">
             <en>Show Notifications</en>
             <uk>Показувати сповіщення</uk>
+            <da>Vis Notifikationer</da>
         </text>
         <text name="rwe_notifications_long">
             <en>Display event notifications on screen</en>
             <uk>Відображати сповіщення про події на екрані</uk>
+            <da>Vis hændelsesnotifikationer på skærmen</da>
         </text>
         <text name="rwe_warnings_short">
             <en>Show Warnings</en>
             <uk>Показувати попередження</uk>
+            <da>Vis Advarsler</da>
         </text>
         <text name="rwe_warnings_long">
             <en>Show event warning messages</en>
             <uk>Відображати попереджувальні повідомлення про події</uk>
+            <da>Vis hændelsesadvarsler</da>
         </text>
         <text name="rwe_show_hud_short">
             <en>Show HUD Panel</en>
             <uk>Показати панель HUD</uk>
+            <da>Vis HUD-panel</da>
         </text>
         <text name="rwe_show_hud_long">
             <en>Show the World Events HUD overlay (F3 to toggle in-game)</en>
             <uk>Показати накладку HUD світових подій (F3 для перемикання в грі)</uk>
+            <da>Vis HUD-overlayet for hændelser (F3 for at slå til/fra i spillet)</da>
         </text>
         <text name="rwe_hud_scale_short">
             <en>HUD Scale</en>
             <uk>Масштаб HUD</uk>
+            <da>HUD-skala</da>
         </text>
         <text name="rwe_hud_scale_long">
             <en>Size of the World Events HUD panel</en>
             <uk>Розмір панелі HUD світових подій</uk>
+            <da>Størrelse på HUD-panelet for hændelser</da>
         </text>
 
         <!-- Categories -->
         <text name="rwe_economic_short">
             <en>Economic Events</en>
             <uk>Економічні події</uk>
+            <da>Økonomiske hændelser</da>
         </text>
         <text name="rwe_economic_long">
             <en>Enable market and economic events</en>
             <uk>Увімкнути ринкові та економічні події</uk>
+            <da>Slå markeds- og økonomiske hændelser til</da>
         </text>
         <text name="rwe_vehicle_short">
             <en>Vehicle Events</en>
             <uk>Події з технікою</uk>
+            <da>Køretøjshændelser</da>
         </text>
         <text name="rwe_vehicle_long">
             <en>Enable vehicle events (speed, fuel, damage)</en>
             <uk>Увімкнути події з технікою (швидкість, паливо, пошкодження)</uk>
+            <da>Aktivér køretøjshændelser (hastighed, brændstof, skader)</da>
         </text>
         <text name="rwe_field_short">
             <en>Field Events</en>
             <uk>Події на полях</uk>
+            <da>Markhændelser</da>
         </text>
         <text name="rwe_field_long">
             <en>Enable crop and field events</en>
             <uk>Увімкнути події з культурами та полями</uk>
+            <da>Aktivér afgrøde- og markhændelser</da>
         </text>
         <text name="rwe_wildlife_short">
             <en>Wildlife Events</en>
             <uk>Події з дикою природою</uk>
+            <da>Dyrelivshændelser</da>
         </text>
         <text name="rwe_wildlife_long">
             <en>Enable wildlife and animal events</en>
             <uk>Увімкнути події з дикою природою та тваринами</uk>
+            <da>Aktivér hændelser med dyreliv og dyr</da>
         </text>
         <text name="rwe_special_short">
             <en>Special Events</en>
             <uk>Особливі події</uk>
+            <da>Særlige hændelser</da>
         </text>
         <text name="rwe_special_long">
             <en>Enable time, XP, and special events</en>
             <uk>Увімкнути події з часом, досвідом та особливі події</uk>
+            <da>Aktivér tids-, XP- og Særlige hændelser</da>
         </text>
 
         <!-- Physics -->
         <text name="rwe_physics_enabled_short">
             <en>Enable Physics Override</en>
             <uk>Увімкнути налаштування фізики</uk>
+            <da>Aktivér fysikoverstyring</da>
         </text>
         <text name="rwe_physics_enabled_long">
             <en>Apply terrain-aware wheel grip and suspension</en>
             <uk>Застосувати зчеплення коліс і підвіску залежно від типу поверхні</uk>
+            <da>Anvend terræntilpasset hjulgreb og affjedring</da>
         </text>
         <text name="rwe_wheel_grip_short">
             <en>Wheel Grip</en>
             <uk>Зчеплення коліс</uk>
+            <da>hjulgreb</da>
         </text>
         <text name="rwe_wheel_grip_long">
             <en>Scale terrain grip values (1.00 = default)</en>
             <uk>Масштаб зчеплення з поверхнею (1.00 = за замовчуванням)</uk>
+            <da>Skaler terrænets grebsværdier (1,00 = standard)</da>
         </text>
         <text name="rwe_suspension_short">
             <en>Suspension Stiffness</en>
             <uk>Жорсткість підвіски</uk>
+            <da>Affjedringsstivhed</da>
         </text>
         <text name="rwe_suspension_long">
             <en>Scale suspension spring force (1.00 = default)</en>
             <uk>Масштаб сили пружини підвіски (1.00 = за замовчуванням)</uk>
+            <da>Skaler affjedringens fjederkraft (1,00 = standard)</da>
         </text>
 
         <!-- Debug -->
         <text name="rwe_physics_info_short">
             <en>Show Physics Info</en>
             <uk>Показати інформацію про фізику</uk>
+            <da>Vis fysikinfo</da>
         </text>
         <text name="rwe_physics_info_long">
             <en>Log per-vehicle speed and grip data each frame</en>
             <uk>Записувати дані швидкості та зчеплення для кожного транспортного засобу щокадру</uk>
+            <da>Log hastigheds- og grebsdata pr. køretøj i hver frame</da>
         </text>
         <text name="rwe_debug_short">
             <en>Debug Mode</en>
             <uk>Режим налагодження</uk>
+            <da>Fejlfindingstilstand</da>
         </text>
         <text name="rwe_debug_long">
             <en>Show verbose Random World Events debug output</en>
             <uk>Показувати детальні діагностичні дані випадкових світових подій</uk>
+            <da>Vis detaljeret debugoutput for tilfældige hændelser</da>
         </text>
 
         <!-- Input action description (shows in keybinding menu) -->
         <text name="input_RWE_TOGGLE_HUD">
             <en>Toggle Random World Events HUD</en>
             <uk>Перемкнути HUD випадкових світових подій</uk>
+            <da>Skift tilfældige hændelser HUD</da>
         </text>
         <text name="input_RWE_TOGGLE_SETTINGS">
             <en>Toggle Random World Events Settings</en>
@@ -293,200 +338,245 @@
             <br>Abrir configurações de eventos aleatórios</br>
             <uk>Відкрити налаштування випадкових подій</uk>
             <ru>Открыть настройки случайных событий</ru>
+            <da>Slå indstillinger for Random World Events til/fra</da>
         </text>
 
         <!-- Help page: category titles -->
         <text name="helpLine_rwe_cat_overview">
             <en>Overview</en>
             <uk>Огляд</uk>
+            <da>Oversigt</da>
         </text>
         <text name="helpLine_rwe_cat_categories">
             <en>Event Categories</en>
             <uk>Категорії подій</uk>
+            <da>Hændelseskategorier</da>
         </text>
         <text name="helpLine_rwe_cat_settings">
             <en>Settings</en>
             <uk>Налаштування</uk>
+            <da>indstillinger</da>
         </text>
         <text name="helpLine_rwe_cat_controls">
             <en>Controls &amp; Commands</en>
             <uk>Керування та команди</uk>
+            <da>Styring &amp; kommandoer</da>
         </text>
 
         <!-- Help page: Overview page 1 -->
         <text name="helpLine_rwe_ov1_title">
             <en>What is Random World Events?</en>
             <uk>Що таке випадкові світові події?</uk>
+            <da> Hvad er Random World Events</da>
         </text>
         <text name="helpLine_rwe_ov1_intro_title">
             <en>Living World</en>
             <uk>Живий світ</uk>
+            <da>Levende verden</da>
         </text>
         <text name="helpLine_rwe_ov1_intro_text">
             <en>Random World Events brings dynamic, unpredictable events to your farm. 53 unique events across five categories fire automatically during play, affecting your economy, vehicles, fields, wildlife, and more. No two playthroughs will feel the same.</en>
             <uk>Випадкові світові події привносять динамічні та непередбачувані події на вашу ферму. 53 унікальні події у п'яти категоріях запускаються автоматично під час гри, впливаючи на економіку, техніку, поля, дику природу та багато іншого. Жодне проходження не буде схожим на попереднє.</uk>
+            <da>Random World Events bringer dynamiske og uforudsigelige hændelser til din gård. 53 unikke hændelser fordelt på fem kategorier udløses automatisk under spillet og påvirker din økonomi, dine køretøjer, marker, dyreliv og meget mere. Hver gennemspilning føles unik.</da>
         </text>
         <text name="helpLine_rwe_ov1_expect_title">
             <en>What to Expect</en>
             <uk>Чого очікувати</uk>
+            <da>Hvad kan du forvente</da>
         </text>
         <text name="helpLine_rwe_ov1_expect_text">
             <en>Events appear as HUD notifications and last for a configurable duration. Some grant bonuses (market booms, fuel refills, crop buffs), while others impose challenges (accidents, price crashes, stampedes). A cooldown timer prevents event spam.</en>
             <uk>Події відображаються як сповіщення HUD і тривають налаштовуваний час. Деякі дають бонуси (підйоми на ринку, поповнення палива, підсилення врожаю), тоді як інші створюють труднощі (аварії, падіння цін, натовпи тварин). Таймер перерви запобігає надмірній кількості подій.</uk>
+            <da>Hændelser vises som HUD-notifikationer og varer i et tidsrum, du selv kan konfigurere. Nogle giver bonusser (markedsboom, brændstofpåfyldning, afgrødebonusser), mens andre skaber udfordringer (ulykker, prisstyrt, paniske dyreflokke). En cooldown-timer sikrer, at hændelser ikke spammer spillet.</da>
         </text>
 
         <!-- Help page: Overview page 2 -->
         <text name="helpLine_rwe_ov2_title">
             <en>How Events Work</en>
             <uk>Як працюють події</uk>
+            <da>Hvordan hændelser virker</da>
         </text>
         <text name="helpLine_rwe_ov2_trigger_title">
             <en>Trigger System</en>
             <uk>Система запуску</uk>
+            <da>Hændelsesudløser</da>
         </text>
         <text name="helpLine_rwe_ov2_trigger_text">
             <en>Each game tick there is a small probability of an event firing, controlled by the Frequency setting (1-10). When an event triggers, a random eligible event from all enabled categories is selected. Only one event can be active at a time.</en>
             <uk>При кожному ігровому тику є невелика ймовірність запуску події, яка контролюється параметром «Частота» (1–10). Коли подія запускається, з усіх увімкнених категорій вибирається випадкова відповідна подія. Одночасно може бути активна лише одна подія.</uk>
+            <da>Ved hvert game-tick er der en lille sandsynlighed for, at en hændelse udløses, styret af indstillingen Hyppighed (1–10). Når en hændelse aktiveres, vælges en tilfældig tilgængelig hændelse fra alle aktiverede kategorier. Kun én hændelse kan være aktiv ad gangen.</da>
         </text>
         <text name="helpLine_rwe_ov2_intensity_title">
             <en>Intensity &amp; Cooldown</en>
             <uk>Інтенсивність та перерва</uk>
+            <da>Intensitet &amp; cooldown</da>
         </text>
         <text name="helpLine_rwe_ov2_intensity_text">
             <en>Intensity (1-5) scales the strength of effects — a level 5 market boom gives a bigger bonus than level 1. After each event, a cooldown period (1-240 minutes) must pass before the next event can fire. Both settings are configurable per savegame.</en>
             <uk>Інтенсивність (1–5) визначає силу ефектів — підйом ринку рівня 5 дає більший бонус, ніж рівень 1. Після кожної події має пройти час перерви (1–240 хвилин), перш ніж може статися наступна подія. Обидва параметри налаштовуються для кожного збереження.</uk>
+            <da>Intensitet (1–5) skalerer styrken af effekterne — et markedsboom på niveau 5 giver en større bonus end niveau 1. Efter hver hændelse skal en cooldown-periode (1–240 minutter) passere, før den næste hændelse kan udløses. Begge indstillinger kan konfigureres separat for hvert savegame.</da>
         </text>
 
         <!-- Help page: Categories / economic -->
         <text name="helpLine_rwe_cat1_title">
             <en>Economic Events</en>
             <uk>Економічні події</uk>
+            <da>Økonomiske hændelser</da>
         </text>
         <text name="helpLine_rwe_cat1_good_title">
             <en>Positive Events (11)</en>
             <uk>Позитивні події (11)</uk>
+            <da>Positive hændelser (11)</da>
         </text>
         <text name="helpLine_rwe_cat1_good_text">
             <en>Government subsidies, market booms, farmer donations, tax refunds, insurance payouts, export opportunities, seed discounts, fertilizer discounts, fuel discounts, equipment discounts, and price-fixing bonuses (temporary elevated sell prices). These events grant direct cash or temporary price bonuses.</en>
             <uk>Державні субсидії, підйоми на ринку, пожертви фермерів, повернення податків, страхові виплати, експортні можливості, знижки на насіння, знижки на добрива, знижки на паливо, знижки на обладнання та цінові бонуси (тимчасово підвищені ціни продажу). Ці події надають пряму готівку або тимчасові цінові бонуси.</uk>
+            <da>Statslige tilskud, markedsboom, donationer fra landmænd, skatterefusioner, forsikringsudbetalinger, eksportmuligheder, rabatter på frø, rabatter på gødning, rabatter på brændstof, rabatter på udstyr samt bonusser fra prisfastsættelse (midlertidigt forhøjede salgspriser). Disse hændelser giver direkte kontanter eller midlertidige prisbonusser.</da>
         </text>
         <text name="helpLine_rwe_cat1_bad_title">
             <en>Negative Events (4)</en>
             <uk>Негативні події (4)</uk>
+            <da>Negative hændelser (4)</da>
         </text>
         <text name="helpLine_rwe_cat1_bad_text">
             <en>Market crashes (reduced sell prices), sudden expenses (immediate cash loss), loan interest charges (percentage of current money), and economic crises (combined market penalty plus ongoing loan costs). High-intensity crises stack both effects. Toggle the Economic category off to disable all of these.</en>
             <uk>Обвали ринку (знижені ціни продажу), раптові витрати (миттєва втрата грошей), нарахування відсотків за кредитом (відсоток від наявних коштів) та економічні кризи (поєднання ринкових штрафів і поточних витрат за кредитом). Кризи високої інтенсивності накопичують обидва ефекти. Вимкніть категорію «Економіка», щоб відключити все це.</uk>
+            <da>Markedsnedbrud (reducerede salgspriser), uforudsete udgifter (øjeblikkeligt pengetab), lånerenter (en procentdel af din nuværende saldo) og økonomiske kriser (kombineret markedstraf plus løbende låneomkostninger). Kriser med høj intensitet kombinerer begge effekter. Slå kategorien Økonomi fra for at deaktivere dem alle.</da>
         </text>
 
         <!-- Help page: Categories / vehicle and field -->
         <text name="helpLine_rwe_cat2_title">
             <en>Vehicle &amp; Field Events</en>
             <uk>Події з технікою та полями</uk>
+            <da>Køretøjs- &amp; markhændelser</da>
         </text>
         <text name="helpLine_rwe_cat2_vehicle_title">
             <en>Vehicle Events (8)</en>
             <uk>Події з технікою (8)</uk>
+            <da>Køretøjshændelser (8)</da>
         </text>
         <text name="helpLine_rwe_cat2_vehicle_text">
             <en>Speed boosts, free fuel refills, fuel leaks, minor accidents with repair bills, full fleet cleaning, visual upgrades, engine trouble (reduced power), and emergency repair bills. Most vehicle events target your currently controlled vehicle.</en>
             <uk>Прискорення, безкоштовне поповнення палива, витік палива, дрібні аварії з рахунками за ремонт, повне чищення парку техніки, візуальні оновлення, проблеми з двигуном (знижена потужність) та екстрені рахунки за ремонт. Більшість подій з технікою стосуються транспортного засобу, яким ви керуєте.</uk>
+            <da>Hastighedsboosts, gratis brændstofpåfyldninger, brændstoflækager, mindre ulykker med reparationsregninger, rengøring af hele køretøjsflåden, visuelle opgraderinger, motorproblemer (reduceret kraft) samt akutte reparationsregninger. De fleste køretøjshændelser påvirker det køretøj, du aktuelt styrer.</da>
         </text>
         <text name="helpLine_rwe_cat2_field_title">
             <en>Field Events (10)</en>
             <uk>Події на полях (10)</uk>
+            <da>Markhændelser (10)</da>
         </text>
         <text name="helpLine_rwe_cat2_field_text">
             <en>Crop yield bonuses and penalties, doubled or halved fertilizer effectiveness, seed growth speed changes, harvest amount modifiers, and field sale price shifts. Field events require at least one field on the map to be eligible.</en>
             <uk>Бонуси та штрафи до врожайності культур, подвоєна або вдвічі знижена ефективність добрив, зміни швидкості росту насіння, модифікатори кількості врожаю та зміни цін продажу з поля. Для подій на полях потрібне хоча б одне поле на карті.</uk>
+            <da>Bonusser og straf på afgrødeudbytte, fordoblet eller halveret effektivitet af gødning, ændringer i frøenes væksthastighed, modifikatorer for høstmængde samt ændringer i markens salgspris. Markhændelser kræver, at der er mindst én mark på kortet for at kunne udløses.</da>
         </text>
 
         <!-- Help page: Categories / special and wildlife -->
         <text name="helpLine_rwe_cat3_title">
             <en>Special &amp; Wildlife Events</en>
             <uk>Особливі події та події з дикою природою</uk>
+            <da>Særlige &amp; dyrelivshændelser</da>
         </text>
         <text name="helpLine_rwe_cat3_special_title">
             <en>Special Events (10)</en>
             <uk>Особливі події (10)</uk>
+            <da>Særlige hændelser (10)</da>
         </text>
         <text name="helpLine_rwe_cat3_special_text">
             <en>Time acceleration and slowdown (affects in-game time scale), XP gain bonuses and penalties, money multipliers, equipment durability changes, better trade prices, and town festivals. Time events restore the original time scale when they end.</en>
             <uk>Прискорення та уповільнення часу (впливає на масштаб ігрового часу), бонуси та штрафи до отримання досвіду, множники грошей, зміни міцності обладнання, кращі торгові ціни та міські фестивалі. Після закінчення часових подій відновлюється початковий масштаб часу.</uk>
+            <da>Tidsacceleration og -opbremsning (påvirker spillets tidsskala), bonusser og straf på XP-optjening, pengemultiplikatorer, ændringer i udstyrets holdbarhed, bedre handelspriser samt byfestivaler. Tidsrelaterede hændelser gendanner den oprindelige tidsskala, når de slutter.</da>
         </text>
         <text name="helpLine_rwe_cat3_wildlife_title">
             <en>Wildlife Events (10)</en>
             <uk>Події з дикою природою (10)</uk>
+            <da>Dyrelivshændelser (10)</da>
         </text>
         <text name="helpLine_rwe_cat3_wildlife_text">
             <en>Bird flocks, beneficial insects, wild stampedes, predator alerts, rabbit infestations, bee swarms, hunting season bonuses, livestock product bonuses and penalties, veterinary bills, and disease scares. Enable the Wildlife category to experience these.</en>
             <uk>Зграї птахів, корисні комахи, дикі натовпи тварин, сповіщення про хижаків, нашестя кролів, рої бджіл, бонуси сезону полювання, бонуси та штрафи до продуктів тваринництва, ветеринарні рахунки та спалахи хвороб. Увімкніть категорію «Дика природа», щоб переживати ці події.</uk>
+            <da>Fugleflokke, nyttige insekter, vilde dyreflokke på flugt, rovdyrvarsler, kaninangreb, bisværme, bonusser i jagtsæsonen, bonusser og straf på husdyrprodukter, dyrlægeregninger samt sygdomsbekymringer. Aktivér kategorien Dyreliv for at opleve disse hændelser.</da>
         </text>
 
         <!-- Help page: Settings / event settings -->
         <text name="helpLine_rwe_set1_title">
             <en>Event Settings</en>
             <uk>Налаштування подій</uk>
+            <da>Hændelsesindstillinger</da>
         </text>
         <text name="helpLine_rwe_set1_freq_title">
             <en>Frequency (1-10)</en>
             <uk>Частота (1–10)</uk>
+            <da>Frekvens (1–10)</da>
         </text>
         <text name="helpLine_rwe_set1_freq_text">
             <en>Controls how often events fire. Higher values increase the per-tick trigger probability. A frequency of 10 means events fire nearly every cooldown period, while 1 makes them very rare. Default is 5 for a balanced experience.</en>
             <uk>Контролює, як часто відбуваються події. Вищі значення збільшують ймовірність запуску за кожен тік. Частота 10 означає, що події відбуваються майже в кожен період перерви, тоді як 1 робить їх дуже рідкісними. За замовчуванням встановлено 5 для збалансованого ігрового процесу.</uk>
+            <da>Styrer, hvor ofte hændelser udløses. Højere værdier øger sandsynligheden for udløsning ved hvert tick. En hyppighed på 10 betyder, at hændelser udløses næsten ved hver cooldown-periode, mens 1 gør dem meget sjældne. Standardværdien er 5 for en afbalanceret oplevelse.</da>
         </text>
         <text name="helpLine_rwe_set1_cool_title">
             <en>Intensity (1-5) &amp; Cooldown (1-240 min)</en>
             <uk>Інтенсивність (1–5) та перерва (1–240 хв)</uk>
+            <da>Intensitet (1–5) &amp; cooldown (1–240 min.)</da>
         </text>
         <text name="helpLine_rwe_set1_cool_text">
             <en>Intensity scales the magnitude of event effects — use lower values for a gentle experience and higher values for dramatic swings. Cooldown sets the minimum in-game minutes between events. Increase cooldown for a calmer, less frequent experience.</en>
             <uk>Інтенсивність визначає масштаб ефектів подій — використовуйте нижчі значення для спокійного ігрового процесу, а вищі — для драматичних змін. Перерва встановлює мінімальний ігровий час між подіями. Збільшіть перерву для спокійнішого і менш частого ігрового процесу.</uk>
+            <da>Intensitet skalerer styrken af hændelsernes effekter — brug lavere værdier for en mere rolig oplevelse og højere værdier for mere dramatiske udsving. Ventetid angiver det minimale antal minutter i spillet mellem hændelser. Øg ventetiden for en roligere oplevelse med færre hændelser.</da>
         </text>
 
         <!-- Help page: Settings / physics settings -->
         <text name="helpLine_rwe_set2_title">
             <en>Physics Settings</en>
             <uk>Налаштування фізики</uk>
+            <da>Fysiske indstillinger</da>
         </text>
         <text name="helpLine_rwe_set2_grip_title">
             <en>Wheel Grip &amp; Suspension</en>
             <uk>Зчеплення коліс та підвіска</uk>
+            <da>Hjulgreb &amp; affjedring</da>
         </text>
         <text name="helpLine_rwe_set2_grip_text">
             <en>The physics system applies terrain-aware wheel friction to your controlled vehicle every frame. Asphalt gives 110% grip, dirt 95%, fields 85%, grass 90%, and snow 70%. The Wheel Grip Multiplier scales all of these values. Suspension Stiffness multiplies spring force.</en>
             <uk>Система фізики застосовує зчеплення коліс залежно від типу поверхні для вашого транспортного засобу щокадру. Асфальт дає 110% зчеплення, бруд — 95%, поля — 85%, трава — 90%, сніг — 70%. Множник зчеплення коліс масштабує всі ці значення. Жорсткість підвіски множить силу пружини.</uk>
+            <da>Fysiksystemet anvender terræntilpasset hjulfriktion på det køretøj, du styrer, i hver frame. Asfalt giver 110 % greb, jord 95 %, marker 85 %, græs 90 % og sne 70 %. Multiplikatoren for hjulgreb skalerer alle disse værdier. Affjedringsstivhed multiplicerer fjederkraften.</da>
         </text>
         <text name="helpLine_rwe_set2_debug_title">
             <en>Debug &amp; Physics Info</en>
             <uk>Налагодження та інформація про фізику</uk>
+            <da>Fejlfinding &amp; Fysisk info</da>
         </text>
         <text name="helpLine_rwe_set2_debug_text">
             <en>Enable Show Physics Info to log per-vehicle speed and multiplier data each frame. Enable Debug Mode for per-wheel grip values. These are useful for tuning your physics settings but may produce verbose console output during normal play.</en>
             <uk>Увімкніть «Показати інформацію про фізику», щоб записувати дані швидкості та множника для кожного транспортного засобу щокадру. Увімкніть режим налагодження для перегляду значень зчеплення кожного колеса. Це корисно для налаштування параметрів фізики, але може призвести до детального виводу в консоль під час звичайної гри.</uk>
+            <da>Aktivér Vis fysikinfo for at logge hastigheds- og multiplikatordata pr. køretøj i hver frame. Aktivér Debugtilstand for grebsværdier pr. hjul. Disse er nyttige til finjustering af dine fysikindstillinger, men kan give meget detaljeret konsoloutput under normal spilbrug.</da>
         </text>
 
         <!-- Help page: Controls -->
         <text name="helpLine_rwe_ctrl_title">
             <en>Controls &amp; Console Commands</en>
             <uk>Керування та консольні команди</uk>
+            <da>Styring &amp; kommandoer</da>
         </text>
         <text name="helpLine_rwe_ctrl_keys_title">
             <en>Keyboard Shortcuts</en>
             <uk>Гарячі клавіші</uk>
+            <da>Genvejstaster</da>
         </text>
         <text name="helpLine_rwe_ctrl_keys_text">
             <en>F3: Open the Random World Events settings screen. F9: Immediately force-trigger a random event (useful for testing). These bindings can be changed in the game's keybinding menu under the Random World Events section.</en>
             <uk>F3: Відкрити екран налаштувань випадкових світових подій. F9: Негайно примусово запустити випадкову подію (корисно для тестування). Ці прив'язки можна змінити в меню прив'язок клавіш гри в розділі «Випадкові світові події».</uk>
+            <da>F3: Åbn indstillingsskærmen for Random World Events. F9: Tving straks en tilfældig hændelse til at udløses (nyttigt til test). Disse tastetildelinger kan ændres i spillets menu for tastetildelinger under sektionen Random World Events.</da>
         </text>
         <text name="helpLine_rwe_ctrl_console_title">
             <en>Console Commands</en>
             <uk>Консольні команди</uk>
+            <da>Kommandoer</da>
         </text>
         <text name="helpLine_rwe_ctrl_console_text">
             <en>Open the developer console and type: rwe (help), rweStatus (current state), rweTest (force trigger), rweEnd (stop active event), rweSettings (open GUI), rweDebug on|off (toggle verbose logging), rweList [category] (list all events).</en>
             <uk>Відкрийте консоль розробника та введіть: rwe (допомога), rweStatus (поточний стан), rweTest (примусовий запуск), rweEnd (зупинити активну подію), rweSettings (відкрити інтерфейс), rweDebug on|off (перемкнути детальне журналювання), rweList [категорія] (список усіх подій).</uk>
+            <da>Åbn udviklerkonsollen og skriv: rwe (hjælp), rweStatus (nuværende status), rweTest (tving en hændelse til at udløses), rweEnd (stop aktiv hændelse), rweSettings (åbn GUI), rweDebug on|off (slå detaljeret logning til/fra), rweList [kategori] (vis alle hændelser).</da>
         </text>
 
         <!-- HUD overlay strings -->
@@ -501,6 +591,7 @@
             <br>HUD RWE exibido</br>
             <uk>HUD RWE показано</uk>
             <ru>HUD RWE показан</ru>
+            <da>RWE HUD aktiveret</da>
         </text>
         <text name="rwe_hud_hidden">
             <en>RWE HUD hidden</en>
@@ -513,6 +604,7 @@
             <br>HUD RWE ocultado</br>
             <uk>HUD RWE приховано</uk>
             <ru>HUD RWE скрыт</ru>
+            <da>RWE HUD deaktiveret</da>
         </text>
         <text name="rwe_hud_title">
             <en>WORLD EVENTS</en>
@@ -525,6 +617,7 @@
             <br>EVENTOS MUNDIAIS</br>
             <uk>СВІТОВІ ПОДІЇ</uk>
             <ru>МИРОВЫЕ СОБЫТИЯ</ru>
+            <da>HÆNDELSER</da>
         </text>
         <text name="rwe_hud_status_on">
             <en>[ON]</en>
@@ -537,6 +630,7 @@
             <br>[LIG]</br>
             <uk>[УВК]</uk>
             <ru>[ВКЛ]</ru>
+            <da>[TÆNDT]</da>
         </text>
         <text name="rwe_hud_status_off">
             <en>[OFF]</en>
@@ -549,6 +643,7 @@
             <br>[DES]</br>
             <uk>[ВИМ]</uk>
             <ru>[ВЫКЛ]</ru>
+            <da>[SlUKKET]</da>
         </text>
         <text name="rwe_hud_ends_in">
             <en>Ends in</en>
@@ -561,6 +656,7 @@
             <br>Termina em</br>
             <uk>Завершується через</uk>
             <ru>Завершится через</ru>
+            <da>Slutter om</da>
         </text>
         <text name="rwe_hud_no_active_event">
             <en>No active event</en>
@@ -573,6 +669,7 @@
             <br>Nenhum evento ativo</br>
             <uk>Немає активної події</uk>
             <ru>Нет активного события</ru>
+            <da>Ingen aktive hændelser</da>
         </text>
         <text name="rwe_hud_ready_to_trigger">
             <en>Ready to trigger</en>
@@ -585,6 +682,7 @@
             <br>Pronto para acionar</br>
             <uk>Готово до запуску</uk>
             <ru>Готов к запуску</ru>
+            <da>Klar til aktivering</da>
         </text>
         <text name="rwe_hud_next_in">
             <en>Next in %dm</en>
@@ -597,6 +695,7 @@
             <br>Próximo em %dm</br>
             <uk>Наступне через %dх</uk>
             <ru>Следующее через %dм</ru>
+            <da>Næste om %dm</da>
         </text>
         <text name="rwe_hud_freq_intensity">
             <en>Freq %d/10  |  Intensity %d/5</en>
@@ -609,6 +708,7 @@
             <br>Freq. %d/10  |  Intensidade %d/5</br>
             <uk>Частота %d/10  |  Інтенс. %d/5</uk>
             <ru>Частота %d/10  |  Интенс. %d/5</ru>
+            <da>Hyppighed %d/10 | Intensitet %d/5</da>
         </text>
         <text name="rwe_hud_hint_edit">
             <en>Drag: move   Corner: resize   RMB: done</en>
@@ -621,6 +721,7 @@
             <br>Arrastar: mover   Canto: redimensionar   RMB: concluído</br>
             <uk>Перетяг: рух   Кут: розмір   ПКМ: готово</uk>
             <ru>Перетащить: переместить   Угол: размер   ПКМ: готово</ru>
+            <da>Træk: flyt Hjørne: ændr størrelse Højreklik: færdig</da>
         </text>
         <text name="rwe_hud_hint_normal">
             <en>[F3]: toggle   RMB: move/resize</en>
@@ -633,6 +734,7 @@
             <br>[F3]: alternar   RMB: mover/redimensionar</br>
             <uk>[F3]: перемкнути   ПКМ: рух/розмір</uk>
             <ru>[F3]: переключить   ПКМ: переместить/размер</ru>
+            <da>[F3]: slå til/fra Højreklik: flyt/ændr størrelse</da>
         </text>
     </l10n>
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.1.6.1</version>
+    <version>2.1.6.2</version>
     <modName>FS25_RandomWorldEvents</modName>
     <title>
         <en>Random World Events</en>

--- a/tools/check-global-leaks.sh
+++ b/tools/check-global-leaks.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Pre-commit hook to detect global variable leaks
+# Install: Copy to .git/hooks/pre-commit and make executable
+
+echo "Checking for global variable leaks..."
+
+# Pattern: indented assignment that looks like parameter reassignment
+# Matches: "    variable = variable or"
+LEAKS=$(grep -rn '^\s\+[a-z][a-zA-Z0-9_]*\s*=\s*[a-z][a-zA-Z0-9_]*\s*or\s*' src/ --include="*.lua" | grep -v 'local ')
+
+if [ -n "$LEAKS" ]; then
+    echo "ERROR: Potential global variable leaks detected!"
+    echo ""
+    echo "The following lines reassign parameters without 'local' keyword:"
+    echo "$LEAKS"
+    echo ""
+    echo "FIX: Add 'local' keyword before variable name:"
+    echo "  BEFORE: cost = cost or 0"
+    echo "  AFTER:  local cost = cost or 0"
+    echo ""
+    exit 1
+fi
+
+echo "No global leaks detected!"
+exit 0

--- a/tools/codebase_stats.js
+++ b/tools/codebase_stats.js
@@ -1,0 +1,450 @@
+#!/usr/bin/env node
+/**
+ * FS25_UsedPlus Codebase Statistics Generator v2.0
+ *
+ * Generates comprehensive, verified statistics about the codebase.
+ * Separates mod code from project support files (docs, tools, etc.)
+ * and produces both terminal output and README-ready markdown.
+ *
+ * Usage:
+ *   node codebase_stats.js            # Full terminal report
+ *   node codebase_stats.js --markdown  # README-ready markdown snippet
+ *
+ * Author: Claude & Samantha
+ * Version: 2.0.0
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const MOD_ROOT = path.dirname(__dirname);
+
+// ─── Terminal colors ──────────────────────────────────────────────────────────
+const c = {
+    cyan:    '\x1b[96m',
+    green:   '\x1b[92m',
+    yellow:  '\x1b[93m',
+    red:     '\x1b[91m',
+    dim:     '\x1b[2m',
+    reset:   '\x1b[0m',
+    bold:    '\x1b[1m',
+};
+
+// ─── Directories to skip entirely ────────────────────────────────────────────
+const SKIP_DIRS = new Set([
+    'node_modules', '.git', 'dist', '.build_temp',
+]);
+
+// ─── "Project support" top-level dirs (not shipped mod code) ─────────────────
+const SUPPORT_DIRS = new Set([
+    'docs', 'screenshots', 'FS25_AI_Coding_Reference', '.github', 'tools',
+]);
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function getAllFiles(dir, fileList = []) {
+    for (const entry of fs.readdirSync(dir)) {
+        const full = path.join(dir, entry);
+        const stat = fs.statSync(full);
+        if (stat.isDirectory()) {
+            if (!SKIP_DIRS.has(entry)) getAllFiles(full, fileList);
+        } else {
+            fileList.push(full);
+        }
+    }
+    return fileList;
+}
+
+function countLines(filePath) {
+    try {
+        const lines = fs.readFileSync(filePath, 'utf8').split('\n');
+        const total = lines.length;
+        const code = lines.filter(l => l.trim().length > 0).length;
+        return { total, code, blank: total - code };
+    } catch {
+        return { total: 0, code: 0, blank: 0 };
+    }
+}
+
+function n(filePath) {
+    // Normalize to forward slashes for consistent matching
+    return path.relative(MOD_ROOT, filePath).replace(/\\/g, '/');
+}
+
+function ext(filePath) {
+    return path.extname(filePath).toLowerCase() || '(none)';
+}
+
+function formatBytes(bytes) {
+    if (bytes < 1024) return bytes + ' B';
+    if (bytes < 1048576) return (bytes / 1024).toFixed(1) + ' KB';
+    if (bytes < 1073741824) return (bytes / 1048576).toFixed(1) + ' MB';
+    return (bytes / 1073741824).toFixed(1) + ' GB';
+}
+
+function formatNum(num) {
+    return num.toLocaleString();
+}
+
+function topDir(relPath) {
+    const parts = relPath.split('/');
+    return parts.length > 1 ? parts[0] : '(root)';
+}
+
+function isModCode(relPath) {
+    const top = topDir(relPath);
+    return !SUPPORT_DIRS.has(top);
+}
+
+// ─── Data collection ──────────────────────────────────────────────────────────
+
+function collectData() {
+    const allFiles = getAllFiles(MOD_ROOT);
+    const data = {
+        allFiles: [],
+        modFiles: [],
+        supportFiles: [],
+        byExt: {},           // ext → { files: [], lines: {total,code,blank} }
+        byDir: {},            // top-level dir → count
+        luaFiles: [],         // { rel, lines } for all Lua
+    };
+
+    for (const filePath of allFiles) {
+        const rel = n(filePath);
+        const e = ext(filePath);
+        const top = topDir(rel);
+        const isMod = isModCode(rel);
+
+        data.allFiles.push({ rel, filePath, ext: e, isMod });
+        if (isMod) data.modFiles.push({ rel, filePath, ext: e });
+        else data.supportFiles.push({ rel, filePath, ext: e });
+
+        // By extension
+        if (!data.byExt[e]) data.byExt[e] = { files: [], lines: { total: 0, code: 0, blank: 0 } };
+        data.byExt[e].files.push(rel);
+
+        // Count lines for text-based code files (skip JSON — inflated by lock files)
+        if (['.lua', '.js', '.xml', '.md', '.yml', '.ps1', '.sh', '.bat'].includes(e)) {
+            const lines = countLines(filePath);
+            data.byExt[e].lines.total += lines.total;
+            data.byExt[e].lines.code += lines.code;
+            data.byExt[e].lines.blank += lines.blank;
+
+            if (e === '.lua') {
+                data.luaFiles.push({ rel, lines: lines.code });
+            }
+        }
+
+        // By directory
+        data.byDir[top] = (data.byDir[top] || 0) + 1;
+    }
+
+    return data;
+}
+
+// ─── Feature counting (verified patterns) ─────────────────────────────────────
+
+function countFeatures(data) {
+    const luaRels = data.allFiles.filter(f => f.ext === '.lua').map(f => f.rel);
+    const xmlRels = data.allFiles.filter(f => f.ext === '.xml').map(f => f.rel);
+
+    // GUI XML — all XML files in gui/ directory
+    const guiXml = xmlRels.filter(f => f.startsWith('gui/') && f.endsWith('.xml'));
+    const dialogXml = guiXml.filter(f => f.includes('Dialog'));
+    const frameXml = guiXml.filter(f => f.includes('Frame'));
+    const otherGuiXml = guiXml.filter(f => !f.includes('Dialog') && !f.includes('Frame'));
+
+    // GUI Lua — all Lua files in src/gui/
+    const guiLua = luaRels.filter(f => f.startsWith('src/gui/'));
+    const dialogLua = guiLua.filter(f => f.includes('Dialog'));
+
+    // Managers — all Lua files in src/managers/ (including sub-directories)
+    const managers = luaRels.filter(f => f.startsWith('src/managers/'));
+
+    // Events — all Lua files in src/events/
+    const events = luaRels.filter(f => f.startsWith('src/events/'));
+
+    // Specializations — all Lua files in src/specializations/
+    const specs = luaRels.filter(f => f.startsWith('src/specializations/'));
+
+    // Extensions — all Lua files in src/extensions/
+    const extensions = luaRels.filter(f => f.startsWith('src/extensions/'));
+
+    // Utilities — all Lua files in src/utils/
+    const utilities = luaRels.filter(f => f.startsWith('src/utils/'));
+
+    // Vehicle scripts — Lua files in vehicles/ root
+    const vehicleScripts = luaRels.filter(f => f.startsWith('vehicles/') && f.endsWith('.lua'));
+
+    // Core — Lua files in src/core/ and src/data/
+    const coreFiles = luaRels.filter(f => f.startsWith('src/core/') || f.startsWith('src/data/'));
+
+    // Translation files — XML files matching translations/translation_*.xml
+    const translationFiles = xmlRels.filter(f => /^translations\/translation_\w+\.xml$/.test(f));
+
+    // Translation key count from English file
+    let translationKeys = 0;
+    const enFile = path.join(MOD_ROOT, 'translations', 'translation_en.xml');
+    if (fs.existsSync(enFile)) {
+        const content = fs.readFileSync(enFile, 'utf8');
+        const matches = content.match(/<e k="/g);
+        translationKeys = matches ? matches.length : 0;
+    }
+
+    // Icons — PNG files in gui/icons/
+    const icons = data.allFiles.filter(f => f.rel.startsWith('gui/icons/') && f.ext === '.png');
+
+    // Assets
+    const ddsFiles = data.allFiles.filter(f => f.ext === '.dds');
+    const i3dFiles = data.allFiles.filter(f => f.ext === '.i3d');
+    const shapeFiles = data.allFiles.filter(f => f.ext === '.shapes');
+
+    // Tools
+    const toolFiles = data.allFiles.filter(f => f.rel.startsWith('tools/'));
+
+    return {
+        guiXml, dialogXml, frameXml, otherGuiXml,
+        guiLua, dialogLua,
+        managers, events, specs, extensions, utilities,
+        vehicleScripts, coreFiles,
+        translationFiles, translationKeys,
+        icons, ddsFiles, i3dFiles, shapeFiles, toolFiles,
+    };
+}
+
+// ─── Per-category line counts (for detailed breakdown) ────────────────────────
+
+function categoryLines(fileList) {
+    let total = 0;
+    const perFile = [];
+    for (const rel of fileList) {
+        const lines = countLines(path.join(MOD_ROOT, rel));
+        total += lines.code;
+        perFile.push({ rel: path.basename(rel, '.lua'), lines: lines.code });
+    }
+    perFile.sort((a, b) => b.lines - a.lines);
+    return { total, perFile };
+}
+
+// ─── Terminal output ──────────────────────────────────────────────────────────
+
+function printTerminal(data, features) {
+    const lua = data.byExt['.lua']?.lines || { total: 0, code: 0, blank: 0 };
+    const xml = data.byExt['.xml']?.lines || { total: 0, code: 0, blank: 0 };
+    const js  = data.byExt['.js']?.lines  || { total: 0, code: 0, blank: 0 };
+    const totalCode = lua.code + xml.code + js.code;
+    const totalSize = data.allFiles.reduce((sum, f) => {
+        try { return sum + fs.statSync(f.filePath).size; } catch { return sum; }
+    }, 0);
+
+    console.log();
+    console.log(c.cyan + '═══════════════════════════════════════════════════════════════════════');
+    console.log('  FS25_UsedPlus — Codebase Statistics v2.0');
+    console.log('═══════════════════════════════════════════════════════════════════════' + c.reset);
+
+    // ── Overall Summary ──
+    console.log();
+    console.log(c.bold + '  OVERALL SUMMARY' + c.reset);
+    console.log(c.dim + '  ─────────────────────────────────────────────────────' + c.reset);
+    console.log(`  Total Files:        ${formatNum(data.allFiles.length)}`);
+    console.log(`    Mod Code:         ${formatNum(data.modFiles.length)}`);
+    console.log(`    Project Support:  ${formatNum(data.supportFiles.length)} ${c.dim}(docs, tools, .github, etc.)${c.reset}`);
+    console.log(`  Total Size:         ${formatBytes(totalSize)}`);
+
+    // ── Code Metrics ──
+    console.log();
+    console.log(c.bold + '  CODE METRICS' + c.reset);
+    console.log(c.dim + '  ─────────────────────────────────────────────────────' + c.reset);
+    console.log(`  Lua:                ${formatNum(lua.code)} lines  ${c.dim}(${data.byExt['.lua']?.files.length || 0} files)${c.reset}`);
+    console.log(`  XML:                ${formatNum(xml.code)} lines  ${c.dim}(${data.byExt['.xml']?.files.length || 0} files)${c.reset}`);
+    console.log(`  JavaScript:         ${formatNum(js.code)} lines  ${c.dim}(${data.byExt['.js']?.files.length || 0} files)${c.reset}`);
+    console.log(`  ${c.green}Total Code:         ${formatNum(totalCode)} lines${c.reset}`);
+
+    // ── Files by Type ──
+    console.log();
+    console.log(c.bold + '  FILES BY TYPE' + c.reset);
+    console.log(c.dim + '  ─────────────────────────────────────────────────────' + c.reset);
+    console.log(`  ${c.dim}${'Type'.padEnd(12)} ${'Count'.padStart(5)}   Lines (Code / Blank)${c.reset}`);
+
+    const sorted = Object.entries(data.byExt).sort((a, b) => b[1].files.length - a[1].files.length);
+    for (const [ext, info] of sorted) {
+        const count = String(info.files.length).padStart(5);
+        if (info.lines.total > 0) {
+            console.log(`  ${ext.padEnd(12)} ${count}   ${formatNum(info.lines.code).padStart(7)} / ${formatNum(info.lines.blank).padStart(5)}`);
+        } else {
+            console.log(`  ${ext.padEnd(12)} ${count}   ${c.dim}(binary)${c.reset}`);
+        }
+    }
+
+    // ── Architecture ──
+    console.log();
+    console.log(c.bold + '  ARCHITECTURE' + c.reset);
+    console.log(c.dim + '  ─────────────────────────────────────────────────────' + c.reset);
+    console.log(`  GUI Screens:        ${features.guiXml.length} XML  ${c.dim}(${features.dialogXml.length} dialogs, ${features.frameXml.length} frames, ${features.otherGuiXml.length} panels)${c.reset}`);
+    console.log(`  GUI Lua:            ${features.guiLua.length} files  ${c.dim}(${features.dialogLua.length} dialog controllers)${c.reset}`);
+    console.log(`  Managers:           ${features.managers.length} files`);
+    console.log(`  Network Events:     ${features.events.length} files`);
+    console.log(`  Specializations:    ${features.specs.length} files`);
+    console.log(`  Extensions:         ${features.extensions.length} files`);
+    console.log(`  Utilities:          ${features.utilities.length} files`);
+    console.log(`  Vehicle Scripts:    ${features.vehicleScripts.length} files`);
+    console.log(`  Core/Data:          ${features.coreFiles.length} files`);
+
+    // ── Assets ──
+    console.log();
+    console.log(c.bold + '  ASSETS' + c.reset);
+    console.log(c.dim + '  ─────────────────────────────────────────────────────' + c.reset);
+    console.log(`  DDS Textures:       ${features.ddsFiles.length}`);
+    console.log(`  GUI Icons (PNG):    ${features.icons.length}`);
+    console.log(`  3D Models (I3D):    ${features.i3dFiles.length}`);
+    console.log(`  Shape Files:        ${features.shapeFiles.length}`);
+
+    // ── Localization ──
+    console.log();
+    console.log(c.bold + '  LOCALIZATION' + c.reset);
+    console.log(c.dim + '  ─────────────────────────────────────────────────────' + c.reset);
+    console.log(`  Languages:          ${features.translationFiles.length}`);
+    console.log(`  Translation Keys:   ${formatNum(features.translationKeys)}`);
+
+    // ── Top 10 Largest Lua Files ──
+    console.log();
+    console.log(c.bold + '  TOP 10 LARGEST LUA FILES' + c.reset);
+    console.log(c.dim + '  ─────────────────────────────────────────────────────' + c.reset);
+    const top10 = data.luaFiles.sort((a, b) => b.lines - a.lines).slice(0, 10);
+    for (let i = 0; i < top10.length; i++) {
+        const f = top10[i];
+        const name = path.basename(f.rel, '.lua');
+        const warn = f.lines > 1500 ? ` ${c.red}⚠ EXCEEDS 1500 LINE LIMIT${c.reset}` : '';
+        console.log(`  ${String(i + 1).padStart(2)}. ${name.padEnd(35)} ${formatNum(f.lines).padStart(6)} lines${warn}`);
+    }
+
+    // ── Detailed Category Breakdowns ──
+    console.log();
+    console.log(c.bold + '  DETAILED CATEGORY BREAKDOWNS' + c.reset);
+    console.log(c.dim + '  ─────────────────────────────────────────────────────' + c.reset);
+
+    const categories = [
+        ['Managers', features.managers],
+        ['Events', features.events],
+        ['Specializations', features.specs],
+        ['Extensions', features.extensions],
+        ['Utilities', features.utilities],
+    ];
+
+    for (const [label, files] of categories) {
+        const cl = categoryLines(files);
+        const topFiles = cl.perFile.slice(0, 4).map(f => `${f.rel} (${formatNum(f.lines)})`).join(' • ');
+        console.log(`  ${c.yellow}${label}${c.reset} (${formatNum(cl.total)} lines):`);
+        console.log(`    ${topFiles}`);
+    }
+
+    // ── Directory Breakdown ──
+    console.log();
+    console.log(c.bold + '  FILES BY DIRECTORY' + c.reset);
+    console.log(c.dim + '  ─────────────────────────────────────────────────────' + c.reset);
+    const sortedDirs = Object.entries(data.byDir).sort((a, b) => b[1] - a[1]);
+    for (const [dir, count] of sortedDirs) {
+        const tag = SUPPORT_DIRS.has(dir) ? ` ${c.dim}(support)${c.reset}` : '';
+        console.log(`  ${dir.padEnd(30)} ${String(count).padStart(4)} files${tag}`);
+    }
+
+    // ── Development Tools ──
+    console.log();
+    console.log(c.bold + '  DEVELOPMENT TOOLS' + c.reset);
+    console.log(c.dim + '  ─────────────────────────────────────────────────────' + c.reset);
+    console.log(`  Tool Scripts:       ${features.toolFiles.length} files`);
+
+    console.log();
+    console.log(c.cyan + '═══════════════════════════════════════════════════════════════════════' + c.reset);
+    console.log();
+}
+
+// ─── Markdown output (for README.md) ──────────────────────────────────────────
+
+function printMarkdown(data, features) {
+    const lua = data.byExt['.lua']?.lines || { total: 0, code: 0, blank: 0 };
+    const xml = data.byExt['.xml']?.lines || { total: 0, code: 0, blank: 0 };
+    const js  = data.byExt['.js']?.lines  || { total: 0, code: 0, blank: 0 };
+    const totalCode = lua.code + xml.code + js.code;
+
+    const luaCount = data.byExt['.lua']?.files.length || 0;
+    const xmlCount = data.byExt['.xml']?.files.length || 0;
+
+    const out = [];
+    out.push('### Codebase Statistics');
+    out.push('');
+    out.push(`- **${formatNum(totalCode)} lines of code** (${formatNum(lua.code)} Lua • ${formatNum(xml.code)} XML • ${formatNum(js.code)} JavaScript)`);
+    out.push(`- **${formatNum(data.modFiles.length)} mod files** (${luaCount} Lua • ${xmlCount} XML • ${features.icons.length} icons • ${features.ddsFiles.length} textures • ${features.i3dFiles.length} 3D models)`);
+    out.push(`- **${features.guiXml.length} GUI screens** (${features.dialogXml.length} dialogs, ${features.frameXml.length} frames, ${features.otherGuiXml.length} panels)`);
+    out.push(`- **${features.managers.length} manager classes** orchestrating game systems`);
+    out.push(`- **${features.events.length} network event modules** for multiplayer sync`);
+    out.push(`- **${features.specs.length} specialization modules** for maintenance systems`);
+    out.push(`- **${features.extensions.length} extension hooks** into base game systems`);
+    out.push(`- **${features.utilities.length} utility/helper modules** for shared logic`);
+    out.push(`- **${features.toolFiles.length} development tools** for build, validation & stats`);
+    out.push(`- **${formatNum(features.translationKeys)} localization keys** translated to ${features.translationFiles.length} languages`);
+    out.push(`- **5 months development** (November 2025 - present)`);
+    out.push('');
+
+    // Detailed breakdown
+    out.push('<details>');
+    out.push('<summary><b>📊 Detailed Architecture Breakdown</b></summary>');
+    out.push('');
+
+    const categories = [
+        ['Manager Layer', features.managers],
+        ['Network Events', features.events],
+        ['Specializations', features.specs],
+        ['Extensions', features.extensions],
+        ['Utilities', features.utilities],
+    ];
+
+    for (const [label, files] of categories) {
+        const cl = categoryLines(files);
+        const topFiles = cl.perFile.slice(0, 4).map(f => `${f.rel} (${formatNum(f.lines)})`).join(' • ');
+        out.push(`**${label}** (${formatNum(cl.total)} lines):`);
+        out.push(`- ${topFiles}`);
+        out.push('');
+    }
+
+    // Dialog categories — count by name pattern
+    const dialogCategories = {
+        'Finance System': features.dialogLua.filter(f => /Finance|Loan|Credit|Payment|Lease|Repossession|Deal/.test(f)),
+        'Marketplace - Buying': features.dialogLua.filter(f => /Search|Used|Preview|Inspection|Negotiation/.test(f)),
+        'Marketplace - Selling': features.dialogLua.filter(f => /Sale|Sell|Offer/.test(f)),
+        'Maintenance & Repair': features.dialogLua.filter(f => /Repair|Maintenance|Fluid|Tire|FaultTracer/.test(f)),
+        'Service Truck': features.dialogLua.filter(f => /ServiceTruck/.test(f)),
+        'Purchase System': features.dialogLua.filter(f => /Purchase|UnifiedLand/.test(f)),
+    };
+
+    out.push('**Dialog Categories**:');
+    const cats = Object.entries(dialogCategories).filter(([, v]) => v.length > 0);
+    out.push('- ' + cats.map(([k, v]) => `${k} (${v.length})`).join(' • '));
+    out.push('');
+    out.push('</details>');
+
+    console.log(out.join('\n'));
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+function main() {
+    const markdownMode = process.argv.includes('--markdown');
+
+    const data = collectData();
+    const features = countFeatures(data);
+
+    if (markdownMode) {
+        printMarkdown(data, features);
+    } else {
+        printTerminal(data, features);
+
+        // Also show the markdown snippet at the end for convenience
+        console.log(c.bold + '  README-READY MARKDOWN (copy below):' + c.reset);
+        console.log(c.dim + '  ─────────────────────────────────────────────────────' + c.reset);
+        console.log();
+        printMarkdown(data, features);
+    }
+}
+
+main();

--- a/tools/extract_log_errors.ps1
+++ b/tools/extract_log_errors.ps1
@@ -1,0 +1,274 @@
+<#
+.SYNOPSIS
+    Extracts RandomWorldEvents-related errors and warnings from FS25 game log.
+
+.DESCRIPTION
+    Parses the Farming Simulator 25 log.txt file and extracts all entries
+    related to the RandomWorldEvents mod, categorizing them by severity and type.
+
+.PARAMETER LogPath
+    Path to the log.txt file. Defaults to the standard FS25 location.
+
+.PARAMETER OutputFile
+    Optional path to save the report. If not specified, outputs to console.
+
+.PARAMETER LastNLines
+    Only analyze the last N lines of the log (useful for large logs).
+
+.EXAMPLE
+    .\extract_log_errors.ps1
+
+.EXAMPLE
+    .\extract_log_errors.ps1 -OutputFile "error_report.txt"
+
+.EXAMPLE
+    .\extract_log_errors.ps1 -LastNLines 5000
+#>
+
+param(
+    [string]$LogPath = "$env:USERPROFILE\Documents\My Games\FarmingSimulator2025\log.txt",
+    [string]$OutputFile = "",
+    [int]$LastNLines = 0
+)
+
+# Colors for console output
+function Write-ColorOutput {
+    param([string]$Message, [string]$Color = "White")
+    Write-Host $Message -ForegroundColor $Color
+}
+
+function Write-Header {
+    param([string]$Text)
+    Write-ColorOutput "`n$('=' * 60)" "Cyan"
+    Write-ColorOutput $Text "Cyan"
+    Write-ColorOutput "$('=' * 60)" "Cyan"
+}
+
+function Write-SubHeader {
+    param([string]$Text)
+    Write-ColorOutput "`n$Text" "Yellow"
+    Write-ColorOutput ("-" * $Text.Length) "Yellow"
+}
+
+# Check if log file exists
+if (-not (Test-Path $LogPath)) {
+    Write-ColorOutput "Error: Log file not found at: $LogPath" "Red"
+    Write-ColorOutput "Make sure you've run the game at least once." "Yellow"
+    exit 1
+}
+
+Write-Header "RandomWorldEvents Log Analyzer"
+Write-ColorOutput "Analyzing: $LogPath" "Gray"
+Write-ColorOutput "Time: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')" "Gray"
+
+# Read log file
+$logContent = Get-Content $LogPath -Raw
+$lines = $logContent -split "`n"
+
+if ($LastNLines -gt 0 -and $lines.Count -gt $LastNLines) {
+    Write-ColorOutput "Analyzing last $LastNLines lines of $($lines.Count) total" "Gray"
+    $lines = $lines | Select-Object -Last $LastNLines
+}
+
+# Initialize counters and collections
+$stats = @{
+    TotalLines = $lines.Count
+    RandomWorldEventsLines = 0
+    Errors = @()
+    Warnings = @()
+    LuaErrors = @()
+    NilAccess = @()
+    XmlErrors = @()
+    LoadSuccess = $false
+    ModVersion = "Unknown"
+}
+
+# Patterns to match
+$patterns = @{
+    # RandomWorldEvents specific patterns
+    RandomWorldEventsLine = 'RWE|FS25_RandomWorldEvents'
+    ModLoaded = 'v(\d+\.\d+\.\d+)'
+
+    # Error patterns
+    LuaError = 'Error: .+\.lua:\d+'
+    LuaRuntime = 'attempt to (call|index|compare|concatenate|perform arithmetic)'
+    NilValue = "attempt to \w+ (?:a )?nil value"
+    XmlParse = 'XML parse error|Could not load XML'
+    Warning = 'Warning:'
+
+    # Specific RandomWorldEvents patterns
+    ManagerInit = '(FinanceManager|UsedVehicleManager|VehicleSaleManager)\s+(initialized|loaded)'
+    DialogError = 'Dialog.*(?:nil|error|failed)'
+    EventError = 'Event.*(?:nil|error|failed)'
+}
+
+# Track context for multi-line errors
+$inStackTrace = $false
+$currentError = @()
+
+foreach ($i in 0..($lines.Count - 1)) {
+    $line = $lines[$i]
+
+    # Check if line is RandomWorldEvents related
+    if ($line -match $patterns.RandomWorldEventsLine) {
+        $stats.RandomWorldEventsLines++
+
+        # Check for mod version
+        if ($line -match $patterns.ModLoaded) {
+            $stats.ModVersion = $matches[1]
+            $stats.LoadSuccess = $true
+        }
+
+        # Check for Lua errors
+        if ($line -match $patterns.LuaError -or $line -match $patterns.LuaRuntime) {
+            $errorEntry = @{
+                Line = $i + 1
+                Text = $line.Trim()
+                Type = "LuaError"
+            }
+
+            # Capture stack trace if present
+            $stackTrace = @($line)
+            $j = $i + 1
+            while ($j -lt $lines.Count -and $lines[$j] -match '^\s+(at|in|\.lua:\d+)') {
+                $stackTrace += $lines[$j]
+                $j++
+            }
+            $errorEntry.StackTrace = $stackTrace -join "`n"
+            $stats.LuaErrors += $errorEntry
+            $stats.Errors += $errorEntry
+        }
+
+        # Check for nil access
+        if ($line -match $patterns.NilValue) {
+            $errorEntry = @{
+                Line = $i + 1
+                Text = $line.Trim()
+                Type = "NilAccess"
+            }
+            $stats.NilAccess += $errorEntry
+            $stats.Errors += $errorEntry
+        }
+
+        # Check for warnings
+        if ($line -match $patterns.Warning) {
+            $stats.Warnings += @{
+                Line = $i + 1
+                Text = $line.Trim()
+                Type = "Warning"
+            }
+        }
+    }
+
+    # Also check for XML errors that might reference our mod
+    if ($line -match $patterns.XmlParse -and $line -match 'RandomWorldEvents') {
+        $stats.XmlErrors += @{
+            Line = $i + 1
+            Text = $line.Trim()
+            Type = "XmlError"
+        }
+        $stats.Errors += $stats.XmlErrors[-1]
+    }
+}
+
+# Generate report
+$report = @()
+$report += "=" * 60
+$report += "RandomWorldEvents Error Report"
+$report += "Generated: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')"
+$report += "=" * 60
+
+$report += "`nSUMMARY"
+$report += "-" * 40
+$report += "Mod Version: $($stats.ModVersion)"
+$report += "Mod Loaded Successfully: $($stats.LoadSuccess)"
+$report += "Total Log Lines: $($stats.TotalLines)"
+$report += "RandomWorldEvents-Related Lines: $($stats.RandomWorldEventsLines)"
+$report += "Errors Found: $($stats.Errors.Count)"
+$report += "Warnings Found: $($stats.Warnings.Count)"
+
+if ($stats.Errors.Count -eq 0 -and $stats.Warnings.Count -eq 0) {
+    $report += "`nNo errors or warnings found - log is clean!"
+    Write-ColorOutput "`nNo errors or warnings found - log is clean!" "Green"
+}
+
+# Detailed error breakdown
+if ($stats.LuaErrors.Count -gt 0) {
+    $report += "`nLUA ERRORS ($($stats.LuaErrors.Count))"
+    $report += "-" * 40
+    foreach ($err in $stats.LuaErrors) {
+        $report += "Line $($err.Line): $($err.Text)"
+        if ($err.StackTrace) {
+            $report += $err.StackTrace
+        }
+        $report += ""
+    }
+
+    Write-SubHeader "LUA ERRORS ($($stats.LuaErrors.Count))"
+    foreach ($err in $stats.LuaErrors | Select-Object -First 5) {
+        Write-ColorOutput "  Line $($err.Line): $($err.Text)" "Red"
+    }
+    if ($stats.LuaErrors.Count -gt 5) {
+        Write-ColorOutput "  ... and $($stats.LuaErrors.Count - 5) more" "Red"
+    }
+}
+
+if ($stats.NilAccess.Count -gt 0) {
+    $report += "`nNIL ACCESS ERRORS ($($stats.NilAccess.Count))"
+    $report += "-" * 40
+    foreach ($err in $stats.NilAccess) {
+        $report += "Line $($err.Line): $($err.Text)"
+    }
+
+    Write-SubHeader "NIL ACCESS ERRORS ($($stats.NilAccess.Count))"
+    foreach ($err in $stats.NilAccess | Select-Object -First 5) {
+        Write-ColorOutput "  Line $($err.Line): $($err.Text)" "Red"
+    }
+    if ($stats.NilAccess.Count -gt 5) {
+        Write-ColorOutput "  ... and $($stats.NilAccess.Count - 5) more" "Red"
+    }
+}
+
+if ($stats.XmlErrors.Count -gt 0) {
+    $report += "`nXML ERRORS ($($stats.XmlErrors.Count))"
+    $report += "-" * 40
+    foreach ($err in $stats.XmlErrors) {
+        $report += "Line $($err.Line): $($err.Text)"
+    }
+
+    Write-SubHeader "XML ERRORS ($($stats.XmlErrors.Count))"
+    foreach ($err in $stats.XmlErrors) {
+        Write-ColorOutput "  Line $($err.Line): $($err.Text)" "Red"
+    }
+}
+
+if ($stats.Warnings.Count -gt 0) {
+    $report += "`nWARNINGS ($($stats.Warnings.Count))"
+    $report += "-" * 40
+    foreach ($warn in $stats.Warnings) {
+        $report += "Line $($warn.Line): $($warn.Text)"
+    }
+
+    Write-SubHeader "WARNINGS ($($stats.Warnings.Count))"
+    foreach ($warn in $stats.Warnings | Select-Object -First 10) {
+        Write-ColorOutput "  Line $($warn.Line): $($warn.Text)" "Yellow"
+    }
+    if ($stats.Warnings.Count -gt 10) {
+        Write-ColorOutput "  ... and $($stats.Warnings.Count - 10) more" "Yellow"
+    }
+}
+
+# Output report
+if ($OutputFile) {
+    $report | Out-File -FilePath $OutputFile -Encoding utf8
+    Write-ColorOutput "`nReport saved to: $OutputFile" "Green"
+} else {
+    Write-Header "END OF REPORT"
+}
+
+# Exit with appropriate code
+if ($stats.Errors.Count -gt 0) {
+    exit 1
+} else {
+    exit 0
+}

--- a/tools/find_global_leaks.js
+++ b/tools/find_global_leaks.js
@@ -1,0 +1,209 @@
+const fs = require('fs');
+const path = require('path');
+
+const srcDir = path.join(__dirname, '..', 'src');
+const outputFile = path.join(__dirname, '..', 'GLOBAL_LEAK_AUDIT.md');
+
+const issues = [];
+let totalFiles = 0;
+
+function isClassDefinition(line) {
+    // Top-level class definitions like "MyClass = {}"
+    return /^[A-Z][a-zA-Z0-9_]*\s*=\s*\{/.test(line);
+}
+
+function isValidGlobal(line) {
+    // Valid patterns that are intentional globals
+    return (
+        /^[A-Z][a-zA-Z0-9_]*\s*=\s*\{/.test(line) ||  // Class definition
+        /^g_[a-zA-Z]/.test(line) ||                    // g_ prefix (intentional global)
+        /^source\(/.test(line) ||                      // source() calls
+        line.includes('self.') ||                       // self references
+        line.includes('spec.') ||                       // spec references
+        line.includes('this.') ||                       // this references
+        /^\s*--/.test(line) ||                         // Comments
+        /^\s*local\s/.test(line) ||                    // local keyword
+        /^\s*\[["'][a-zA-Z_]/.test(line) ||           // Table key assignment
+        /^\s*[A-Z_]+\s*=/.test(line.trim()) &&         // CONSTANT = value (in table def)
+          line.trim().endsWith(',')
+    );
+}
+
+function analyzeLine(line, lineNum, filePath) {
+    const trimmed = line.trim();
+
+    // Skip empty lines, comments, and lines starting with keywords
+    if (!trimmed || trimmed.startsWith('--') || trimmed.startsWith('local ')) {
+        return null;
+    }
+
+    // Look for assignment without local
+    const match = trimmed.match(/^([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*([^=].*)/);
+    if (match && line.startsWith('    ')) {  // Indented = inside a function
+        const varName = match[1];
+        const value = match[2];
+
+        // Filter out valid patterns
+        if (varName === 'self' || varName === 'spec' || varName === 'this') return null;
+        if (varName.startsWith('g_')) return null;
+        if (isValidGlobal(line)) return null;
+
+        // Check if it's a table field (has dots before)
+        if (line.includes('.') && line.indexOf('.') < line.indexOf('=')) return null;
+
+        // Potential leak!
+        return {
+            file: filePath,
+            line: lineNum,
+            variable: varName,
+            value: value.substring(0, 50),  // Truncate long values
+            code: line
+        };
+    }
+
+    return null;
+}
+
+function analyzeFile(filePath) {
+    const content = fs.readFileSync(filePath, 'utf8');
+    const lines = content.split('\n');
+    const fileIssues = [];
+
+    lines.forEach((line, idx) => {
+        const issue = analyzeLine(line, idx + 1, filePath);
+        if (issue) {
+            fileIssues.push(issue);
+        }
+    });
+
+    return fileIssues;
+}
+
+function scanDirectory(dir) {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+    for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name);
+
+        if (entry.isDirectory()) {
+            scanDirectory(fullPath);
+        } else if (entry.isFile() && entry.name.endsWith('.lua')) {
+            totalFiles++;
+            const fileIssues = analyzeFile(fullPath);
+            issues.push(...fileIssues);
+        }
+    }
+}
+
+function categorizeIssue(issue) {
+    const varName = issue.variable;
+
+    // High severity: loop counters, common temp vars
+    if (['i', 'j', 'k', 'count', 'index', 'total', 'sum'].includes(varName)) {
+        return 'HIGH';
+    }
+
+    // High: variables used in calculations
+    if (['score', 'result', 'value', 'amount', 'price', 'cost'].includes(varName)) {
+        return 'HIGH';
+    }
+
+    // Medium: descriptive names that might be temps
+    if (varName.endsWith('Score') || varName.endsWith('Bonus') ||
+        varName.endsWith('Penalty') || varName.endsWith('Total')) {
+        return 'MEDIUM';
+    }
+
+    // Low: everything else
+    return 'LOW';
+}
+
+function generateReport() {
+    const high = issues.filter(i => categorizeIssue(i) === 'HIGH');
+    const medium = issues.filter(i => categorizeIssue(i) === 'MEDIUM');
+    const low = issues.filter(i => categorizeIssue(i) === 'LOW');
+
+    let report = `# GLOBAL VARIABLE LEAK AUDIT - FS25_UsedPlus\n\n`;
+    report += `**Generated:** ${new Date().toISOString()}\n`;
+    report += `**Total Lua files scanned:** ${totalFiles}\n`;
+    report += `**Potential leaks found:** ${issues.length}\n\n`;
+    report += `## Severity Breakdown\n\n`;
+    report += `- **HIGH:** ${high.length} (immediate fix recommended)\n`;
+    report += `- **MEDIUM:** ${medium.length} (review needed)\n`;
+    report += `- **LOW:** ${low.length} (low priority)\n\n`;
+    report += `---\n\n`;
+
+    function writeSection(title, items) {
+        if (items.length === 0) return '';
+
+        let section = `## ${title}\n\n`;
+
+        // Group by file
+        const byFile = {};
+        items.forEach(issue => {
+            const relPath = issue.file.replace(/\\/g, '/').split('/src/')[1];
+            if (!byFile[relPath]) byFile[relPath] = [];
+            byFile[relPath].push(issue);
+        });
+
+        Object.keys(byFile).sort().forEach(file => {
+            section += `### \`src/${file}\`\n\n`;
+
+            byFile[file].forEach(issue => {
+                section += `**Line ${issue.line}:** \`${issue.variable}\`\n`;
+                section += `\`\`\`lua\n${issue.code.trim()}\n\`\`\`\n`;
+                section += `**Recommendation:** Add \`local\` keyword before \`${issue.variable}\`\n\n`;
+            });
+
+            section += `---\n\n`;
+        });
+
+        return section;
+    }
+
+    report += writeSection('HIGH SEVERITY', high);
+    report += writeSection('MEDIUM SEVERITY', medium);
+    report += writeSection('LOW SEVERITY', low);
+
+    report += `## Summary & Recommendations\n\n`;
+    report += `### Pattern Analysis\n\n`;
+
+    const varCounts = {};
+    issues.forEach(i => {
+        varCounts[i.variable] = (varCounts[i.variable] || 0) + 1;
+    });
+
+    const sorted = Object.entries(varCounts).sort((a, b) => b[1] - a[1]);
+    report += `**Most common leaked variable names:**\n\n`;
+    sorted.slice(0, 10).forEach(([name, count]) => {
+        report += `- \`${name}\`: ${count} occurrences\n`;
+    });
+
+    report += `\n### General Recommendations\n\n`;
+    report += `1. **Add \`local\` keyword** to all variable assignments inside functions\n`;
+    report += `2. **For loop counters** like \`i\`, \`j\`, \`count\`: Always use \`local for i = 1, n do\`\n`;
+    report += `3. **For calculations**: Declare temps as \`local score = 0\` at function start\n`;
+    report += `4. **Review HIGH severity** items first - these are most likely to cause bugs\n`;
+    report += `5. **Test thoroughly** after fixes - global leaks can have subtle cross-module effects\n\n`;
+
+    report += `### Known Safe Patterns (Excluded)\n\n`;
+    report += `- Class definitions: \`MyClass = {}\` at top level\n`;
+    report += `- Intentional globals: \`g_myGlobal = ...\`\n`;
+    report += `- Self/spec references: \`self.field = ...\`, \`spec.field = ...\`\n`;
+    report += `- Table field assignments: \`myTable.field = ...\`\n`;
+    report += `- Constants in table definitions: \`CONSTANT_NAME = value,\`\n\n`;
+
+    return report;
+}
+
+// Run the scan
+console.log('Scanning for global variable leaks...');
+scanDirectory(srcDir);
+
+const report = generateReport();
+fs.writeFileSync(outputFile, report);
+
+console.log(`\nAudit complete!`);
+console.log(`- Files scanned: ${totalFiles}`);
+console.log(`- Potential leaks: ${issues.length}`);
+console.log(`- Report written to: ${outputFile}`);

--- a/tools/find_global_leaks_v2.js
+++ b/tools/find_global_leaks_v2.js
@@ -1,0 +1,256 @@
+const fs = require('fs');
+const path = require('path');
+
+const srcDir = path.join(__dirname, '..', 'src');
+const outputFile = path.join(__dirname, '..', 'GLOBAL_LEAK_AUDIT.md');
+
+const issues = [];
+let totalFiles = 0;
+
+function analyzeFile(filePath) {
+    const content = fs.readFileSync(filePath, 'utf8');
+    const lines = content.split('\n');
+    const fileIssues = [];
+
+    // Track local variables per function scope
+    let inFunction = false;
+    let functionDepth = 0;
+    let localVars = new Set();
+    let linesBefore = [];
+
+    lines.forEach((line, idx) => {
+        const trimmed = line.trim();
+        const lineNum = idx + 1;
+
+        // Track function scope
+        if (/^function\s/.test(trimmed) || /\sfunction\s*\(/.test(trimmed)) {
+            inFunction = true;
+            functionDepth = 0;
+            localVars = new Set();
+        }
+
+        // Track 'end' keywords (rough depth tracking)
+        const endMatches = line.match(/\bend\b/g);
+        if (endMatches) {
+            functionDepth -= endMatches.length;
+            if (functionDepth <= 0) {
+                inFunction = false;
+                localVars.clear();
+            }
+        }
+
+        // Track 'do', 'then', 'repeat' keywords (increase depth)
+        if (/\b(do|then|repeat)\b/.test(line)) {
+            functionDepth++;
+        }
+
+        // Collect local variable declarations
+        const localMatch = trimmed.match(/^local\s+([a-zA-Z_][a-zA-Z0-9_]*)/);
+        if (localMatch) {
+            localVars.add(localMatch[1]);
+        }
+
+        // Look for assignments without 'local' inside functions
+        if (inFunction && line.startsWith('    ')) {  // Indented
+            // Skip comments
+            if (trimmed.startsWith('--')) {
+                linesBefore.push(line);
+                return;
+            }
+
+            // Match variable assignment (not table field, not self/spec)
+            const match = trimmed.match(/^([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*([^=].*)/);
+            if (match) {
+                const varName = match[1];
+                const value = match[2];
+
+                // Filter out safe patterns
+                if (varName === 'self' || varName === 'spec' || varName === 'this') {
+                    linesBefore.push(line);
+                    return;
+                }
+                if (varName.startsWith('g_')) {
+                    linesBefore.push(line);
+                    return;
+                }
+                if (localVars.has(varName)) {
+                    // This is modifying a local variable (safe!)
+                    linesBefore.push(line);
+                    return;
+                }
+                if (line.includes('.') && line.indexOf('.') < line.indexOf('=')) {
+                    // Table field assignment like foo.bar = ...
+                    linesBefore.push(line);
+                    return;
+                }
+                if (trimmed.endsWith(',') || trimmed.endsWith('},')) {
+                    // Part of table initialization
+                    linesBefore.push(line);
+                    return;
+                }
+
+                // POTENTIAL LEAK!
+                const context = [
+                    ...linesBefore.slice(-2),
+                    line,
+                    ...lines.slice(idx + 1, idx + 3)
+                ].join('\n');
+
+                fileIssues.push({
+                    file: filePath,
+                    line: lineNum,
+                    variable: varName,
+                    value: value.substring(0, 50),
+                    code: line.trim(),
+                    context: context
+                });
+            }
+        }
+
+        // Keep last 3 lines for context
+        linesBefore.push(line);
+        if (linesBefore.length > 3) {
+            linesBefore.shift();
+        }
+    });
+
+    return fileIssues;
+}
+
+function scanDirectory(dir) {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+    for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name);
+
+        if (entry.isDirectory()) {
+            scanDirectory(fullPath);
+        } else if (entry.isFile() && entry.name.endsWith('.lua')) {
+            totalFiles++;
+            const fileIssues = analyzeFile(fullPath);
+            issues.push(...fileIssues);
+        }
+    }
+}
+
+function categorizeIssue(issue) {
+    const varName = issue.variable;
+
+    // High severity: loop counters, common temp vars
+    if (['i', 'j', 'k', 'count', 'index', 'total', 'sum', 'result'].includes(varName)) {
+        return 'HIGH';
+    }
+
+    // High: variables used in calculations
+    if (['score', 'value', 'amount', 'price', 'cost', 'balance'].includes(varName)) {
+        return 'HIGH';
+    }
+
+    // Medium: descriptive names that might be temps
+    if (varName.endsWith('Score') || varName.endsWith('Bonus') ||
+        varName.endsWith('Penalty') || varName.endsWith('Total') ||
+        varName.endsWith('Index') || varName.endsWith('Count')) {
+        return 'MEDIUM';
+    }
+
+    // Low: everything else
+    return 'LOW';
+}
+
+function generateReport() {
+    const high = issues.filter(i => categorizeIssue(i) === 'HIGH');
+    const medium = issues.filter(i => categorizeIssue(i) === 'MEDIUM');
+    const low = issues.filter(i => categorizeIssue(i) === 'LOW');
+
+    let report = `# GLOBAL VARIABLE LEAK AUDIT - FS25_UsedPlus\n\n`;
+    report += `**Generated:** ${new Date().toISOString()}\n`;
+    report += `**Total Lua files scanned:** ${totalFiles}\n`;
+    report += `**Potential leaks found:** ${issues.length}\n\n`;
+    report += `## Severity Breakdown\n\n`;
+    report += `- **HIGH:** ${high.length} (immediate fix recommended)\n`;
+    report += `- **MEDIUM:** ${medium.length} (review needed)\n`;
+    report += `- **LOW:** ${low.length} (low priority)\n\n`;
+    report += `---\n\n`;
+
+    function writeSection(title, items) {
+        if (items.length === 0) return '';
+
+        let section = `## ${title}\n\n`;
+
+        // Group by file
+        const byFile = {};
+        items.forEach(issue => {
+            const relPath = issue.file.replace(/\\/g, '/').split('/src/')[1];
+            if (!byFile[relPath]) byFile[relPath] = [];
+            byFile[relPath].push(issue);
+        });
+
+        Object.keys(byFile).sort().forEach(file => {
+            section += `### \`src/${file}\`\n\n`;
+
+            byFile[file].forEach(issue => {
+                section += `**Line ${issue.line}:** \`${issue.variable} = ${issue.value}\`\n\n`;
+                section += `\`\`\`lua\n${issue.context}\n\`\`\`\n\n`;
+                section += `**Issue:** Variable \`${issue.variable}\` is assigned without \`local\` keyword.\n`;
+                section += `**Fix:** Add \`local ${issue.variable}\` before first use, or add \`local\` to this line.\n\n`;
+                section += `---\n\n`;
+            });
+        });
+
+        return section;
+    }
+
+    report += writeSection('HIGH SEVERITY LEAKS', high);
+    report += writeSection('MEDIUM SEVERITY LEAKS', medium);
+    report += writeSection('LOW SEVERITY LEAKS', low);
+
+    report += `## Summary & Recommendations\n\n`;
+    report += `### Pattern Analysis\n\n`;
+
+    const varCounts = {};
+    issues.forEach(i => {
+        varCounts[i.variable] = (varCounts[i.variable] || 0) + 1;
+    });
+
+    const sorted = Object.entries(varCounts).sort((a, b) => b[1] - a[1]);
+    report += `**Most common leaked variable names:**\n\n`;
+    sorted.slice(0, 15).forEach(([name, count]) => {
+        report += `- \`${name}\`: ${count} occurrences\n`;
+    });
+
+    report += `\n### General Recommendations\n\n`;
+    report += `1. **Add \`local\` keyword** to all variable declarations\n`;
+    report += `2. **For loop counters**: Use \`for i = 1, n do\` (implicit local) or \`local i; for i = ...\`\n`;
+    report += `3. **For calculations**: Declare temps as \`local score = 0\` at function start\n`;
+    report += `4. **Review HIGH severity** items first - these are most likely to cause bugs\n`;
+    report += `5. **Test thoroughly** after fixes - global leaks can have subtle effects\n\n`;
+
+    report += `### Impact of Global Leaks\n\n`;
+    report += `Global variables in Lua can cause:\n`;
+    report += `- **Cross-contamination**: Variable values leak between function calls\n`;
+    report += `- **Multiplayer bugs**: Server/client state corruption\n`;
+    report += `- **Hard-to-debug issues**: Values mysteriously changing\n`;
+    report += `- **Performance**: Global table lookups are slower than locals\n\n`;
+
+    report += `### Known Safe Patterns (Excluded from Report)\n\n`;
+    report += `- Class definitions: \`MyClass = {}\` at top level\n`;
+    report += `- Intentional globals: \`g_myGlobal = ...\`\n`;
+    report += `- Self/spec references: \`self.field = ...\`, \`spec.field = ...\`\n`;
+    report += `- Table field assignments: \`myTable.field = ...\`\n`;
+    report += `- Local variable modifications: \`score = score + 10\` (if \`local score\` was declared earlier)\n`;
+    report += `- Table initializations: Lines ending with \`,\` or \`},\`\n\n`;
+
+    return report;
+}
+
+// Run the scan
+console.log('Scanning for global variable leaks (v2 - scope-aware)...');
+scanDirectory(srcDir);
+
+const report = generateReport();
+fs.writeFileSync(outputFile, report);
+
+console.log(`\nAudit complete!`);
+console.log(`- Files scanned: ${totalFiles}`);
+console.log(`- Potential leaks: ${issues.length}`);
+console.log(`- Report written to: ${outputFile}`);

--- a/tools/find_unused.js
+++ b/tools/find_unused.js
@@ -1,0 +1,1065 @@
+#!/usr/bin/env node
+/**
+ * FS25_UsedPlus - Find Unused Code Scanner
+ *
+ * Scans the codebase for potentially orphaned:
+ * - Lua files not registered in modDesc.xml
+ * - Dialog files (.lua + .xml) not called by DialogLoader or getInstance
+ * - Functions defined but never referenced elsewhere
+ *
+ * Usage:
+ *   node find_unused.js [--verbose] [--check-functions]
+ *
+ * Author: Claude & Samantha
+ * Version: 1.3.0 - Added vanilla hooks, event subscriptions, vehicle metrics, malfunctions
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// ANSI colors
+const colors = {
+    red: '\x1b[91m',
+    green: '\x1b[92m',
+    yellow: '\x1b[93m',
+    blue: '\x1b[94m',
+    cyan: '\x1b[96m',
+    reset: '\x1b[0m',
+    bold: '\x1b[1m'
+};
+
+/**
+ * Find the mod root directory (where modDesc.xml lives)
+ */
+function getModRoot() {
+    let dir = __dirname;
+
+    // Go up from tools/ to mod root
+    const parentDir = path.dirname(dir);
+    if (fs.existsSync(path.join(parentDir, 'modDesc.xml'))) {
+        return parentDir;
+    }
+
+    // Try current directory
+    if (fs.existsSync('modDesc.xml')) {
+        return process.cwd();
+    }
+
+    console.error(`${colors.red}Error: Cannot find modDesc.xml${colors.reset}`);
+    process.exit(1);
+}
+
+/**
+ * Parse modDesc.xml and get registered source files
+ */
+function parseModDescSources(modRoot) {
+    const modDescPath = path.join(modRoot, 'modDesc.xml');
+    const content = fs.readFileSync(modDescPath, 'utf8');
+
+    const registered = new Set();
+    const regex = /sourceFile\s+filename="([^"]+)"/g;
+    let match;
+
+    while ((match = regex.exec(content)) !== null) {
+        registered.add(match[1].replace(/\//g, path.sep));
+    }
+
+    return registered;
+}
+
+/**
+ * Recursively find all files matching a pattern
+ */
+function findFiles(dir, pattern, results = []) {
+    if (!fs.existsSync(dir)) return results;
+
+    const files = fs.readdirSync(dir);
+    for (const file of files) {
+        const filePath = path.join(dir, file);
+        const stat = fs.statSync(filePath);
+
+        if (stat.isDirectory()) {
+            findFiles(filePath, pattern, results);
+        } else if (pattern.test(file)) {
+            results.push(filePath);
+        }
+    }
+
+    return results;
+}
+
+/**
+ * Find all Lua files in src/
+ */
+function findAllLuaFiles(modRoot) {
+    const srcDir = path.join(modRoot, 'src');
+    const files = findFiles(srcDir, /\.lua$/);
+
+    return new Set(files.map(f => path.relative(modRoot, f)));
+}
+
+/**
+ * Find all dialog files (paired .lua and .xml)
+ */
+function findAllDialogs(modRoot) {
+    const dialogs = {};
+
+    // Find Lua dialog files in src/gui
+    const guiDir = path.join(modRoot, 'src', 'gui');
+    if (fs.existsSync(guiDir)) {
+        const luaFiles = findFiles(guiDir, /Dialog\.lua$/);
+        for (const file of luaFiles) {
+            const name = path.basename(file, '.lua');
+            dialogs[name] = { lua: file, xml: null };
+        }
+    }
+
+    // Find XML dialog files in gui/
+    const xmlDir = path.join(modRoot, 'gui');
+    if (fs.existsSync(xmlDir)) {
+        const xmlFiles = findFiles(xmlDir, /Dialog\.xml$/);
+        for (const file of xmlFiles) {
+            const name = path.basename(file, '.xml');
+            if (dialogs[name]) {
+                dialogs[name].xml = file;
+            } else {
+                dialogs[name] = { lua: null, xml: file };
+            }
+        }
+    }
+
+    return dialogs;
+}
+
+/**
+ * Search for references to a dialog in all Lua files
+ * v1.0.1: Now searches src/, vehicles/, placeables/ directories
+ */
+function searchDialogReferences(modRoot, dialogName) {
+    const patterns = [
+        new RegExp(`DialogLoader\\.show\\s*\\(\\s*["']?${dialogName}["']?`),
+        new RegExp(`DialogLoader\\.register\\s*\\(\\s*["']${dialogName}["']`),
+        new RegExp(`${dialogName}\\.getInstance`),
+        new RegExp(`${dialogName}\\.show`),
+        new RegExp(`${dialogName}\\.new`),
+        new RegExp(`g_gui:loadGui\\s*\\([^,]+,\\s*["']?${dialogName}["']?`),
+        new RegExp(`g_gui:showDialog\\s*\\(\\s*["']${dialogName}["']`),
+        new RegExp(`showDialog\\s*\\(\\s*["']?${dialogName}["']?`)
+    ];
+
+    // Search multiple directories - v1.0.1
+    const searchDirs = ['src', 'vehicles', 'placeables'];
+    let luaFiles = [];
+    for (const dir of searchDirs) {
+        const dirPath = path.join(modRoot, dir);
+        if (fs.existsSync(dirPath)) {
+            luaFiles = luaFiles.concat(findFiles(dirPath, /\.lua$/));
+        }
+    }
+
+    const references = [];
+
+    for (const file of luaFiles) {
+        // Skip the dialog's own file
+        if (path.basename(file, '.lua') === dialogName) continue;
+
+        try {
+            const content = fs.readFileSync(file, 'utf8');
+            for (const pattern of patterns) {
+                if (pattern.test(content)) {
+                    references.push(path.relative(modRoot, file));
+                    break;
+                }
+            }
+        } catch (e) {
+            // Ignore read errors
+        }
+    }
+
+    return references;
+}
+
+/**
+ * Count lines of code in a file (excluding blank lines and comments)
+ */
+function countLinesOfCode(filePath) {
+    try {
+        const content = fs.readFileSync(filePath, 'utf8');
+        const lines = content.split('\n');
+        let codeLines = 0;
+        let commentLines = 0;
+        let blankLines = 0;
+        let inBlockComment = false;
+
+        for (const line of lines) {
+            const trimmed = line.trim();
+
+            // Blank line
+            if (trimmed === '') {
+                blankLines++;
+                continue;
+            }
+
+            // Block comment handling (Lua uses --[[ ]])
+            if (inBlockComment) {
+                commentLines++;
+                if (trimmed.includes(']]')) {
+                    inBlockComment = false;
+                }
+                continue;
+            }
+
+            // Start of block comment
+            if (trimmed.startsWith('--[[')) {
+                commentLines++;
+                if (!trimmed.includes(']]')) {
+                    inBlockComment = true;
+                }
+                continue;
+            }
+
+            // Single line comment
+            if (trimmed.startsWith('--')) {
+                commentLines++;
+                continue;
+            }
+
+            codeLines++;
+        }
+
+        return { total: lines.length, code: codeLines, comments: commentLines, blank: blankLines };
+    } catch (e) {
+        return { total: 0, code: 0, comments: 0, blank: 0 };
+    }
+}
+
+/**
+ * Get file size in a human-readable format
+ */
+function formatFileSize(bytes) {
+    if (bytes < 1024) return bytes + ' B';
+    if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
+    return (bytes / (1024 * 1024)).toFixed(2) + ' MB';
+}
+
+/**
+ * Gather codebase statistics
+ */
+function gatherStatistics(modRoot) {
+    const stats = {
+        lua: {
+            total: 0,
+            byCategory: {},
+            totalLines: 0,
+            codeLines: 0,
+            commentLines: 0,
+            blankLines: 0,
+            totalSize: 0,
+            largestFiles: []
+        },
+        xml: {
+            total: 0,
+            gui: 0,
+            translations: 0,
+            other: 0,
+            totalSize: 0
+        },
+        dialogs: 0,
+        events: 0,
+        managers: 0,
+        extensions: 0,
+        specializations: 0,
+        utils: 0
+    };
+
+    // Categories to track
+    const categories = {
+        'src/gui': 'GUI Screens',
+        'src/gui/financepanels': 'Finance Panels',
+        'src/events': 'Network Events',
+        'src/managers': 'Managers',
+        'src/managers/usedvehicle': 'Used Vehicle Modules',
+        'src/extensions': 'Extensions',
+        'src/specializations': 'Specializations',
+        'src/specializations/maintenance': 'Maintenance Modules',
+        'src/utils': 'Utilities',
+        'src/data': 'Data Classes',
+        'src/settings': 'Settings',
+        'src/core': 'Core',
+        'vehicles': 'Vehicles',
+        'placeables': 'Placeables'
+    };
+
+    // Initialize categories
+    for (const cat of Object.values(categories)) {
+        stats.lua.byCategory[cat] = { files: 0, lines: 0 };
+    }
+    stats.lua.byCategory['Other'] = { files: 0, lines: 0 };
+
+    // Scan all Lua files
+    const luaDirs = ['src', 'vehicles', 'placeables'];
+    const allLuaFiles = [];
+
+    for (const dir of luaDirs) {
+        const dirPath = path.join(modRoot, dir);
+        if (fs.existsSync(dirPath)) {
+            const files = findFiles(dirPath, /\.lua$/);
+            allLuaFiles.push(...files);
+        }
+    }
+
+    for (const file of allLuaFiles) {
+        const relPath = path.relative(modRoot, file).replace(/\\/g, '/');
+        const fileStat = fs.statSync(file);
+        const lineStats = countLinesOfCode(file);
+
+        stats.lua.total++;
+        stats.lua.totalLines += lineStats.total;
+        stats.lua.codeLines += lineStats.code;
+        stats.lua.commentLines += lineStats.comments;
+        stats.lua.blankLines += lineStats.blank;
+        stats.lua.totalSize += fileStat.size;
+
+        // Track largest files
+        stats.lua.largestFiles.push({
+            name: path.basename(file),
+            path: relPath,
+            lines: lineStats.total,
+            code: lineStats.code,
+            size: fileStat.size
+        });
+
+        // Categorize
+        let categorized = false;
+        for (const [prefix, catName] of Object.entries(categories)) {
+            if (relPath.startsWith(prefix)) {
+                // Use most specific match
+                const currentDepth = prefix.split('/').length;
+                let foundBetter = false;
+                for (const [otherPrefix, otherCat] of Object.entries(categories)) {
+                    if (relPath.startsWith(otherPrefix) &&
+                        otherPrefix.split('/').length > currentDepth) {
+                        foundBetter = true;
+                        break;
+                    }
+                }
+                if (!foundBetter) {
+                    stats.lua.byCategory[catName].files++;
+                    stats.lua.byCategory[catName].lines += lineStats.code;
+                    categorized = true;
+                    break;
+                }
+            }
+        }
+        if (!categorized) {
+            stats.lua.byCategory['Other'].files++;
+            stats.lua.byCategory['Other'].lines += lineStats.code;
+        }
+
+        // Count specific types
+        const fileName = path.basename(file);
+        if (fileName.endsWith('Dialog.lua')) stats.dialogs++;
+        if (fileName.endsWith('Event.lua') || fileName.endsWith('Events.lua')) stats.events++;
+        if (fileName.endsWith('Manager.lua')) stats.managers++;
+        if (fileName.endsWith('Extension.lua')) stats.extensions++;
+    }
+
+    // Sort largest files
+    stats.lua.largestFiles.sort((a, b) => b.lines - a.lines);
+    stats.lua.largestFiles = stats.lua.largestFiles.slice(0, 10);
+
+    // Count XML files
+    const xmlDirs = ['gui', 'translations'];
+    for (const dir of xmlDirs) {
+        const dirPath = path.join(modRoot, dir);
+        if (fs.existsSync(dirPath)) {
+            const files = findFiles(dirPath, /\.xml$/);
+            for (const file of files) {
+                const fileStat = fs.statSync(file);
+                stats.xml.total++;
+                stats.xml.totalSize += fileStat.size;
+
+                if (dir === 'gui') stats.xml.gui++;
+                else if (dir === 'translations') stats.xml.translations++;
+                else stats.xml.other++;
+            }
+        }
+    }
+
+    return stats;
+}
+
+/**
+ * Print codebase statistics
+ */
+function printStatistics(stats) {
+    console.log(`\n${colors.bold}${colors.blue}=== Codebase Statistics ===${colors.reset}\n`);
+
+    // Overview
+    console.log(`${colors.bold}Overview:${colors.reset}`);
+    console.log(`  Lua Files:        ${stats.lua.total}`);
+    console.log(`  XML Files:        ${stats.xml.total} (${stats.xml.gui} GUI, ${stats.xml.translations} translations)`);
+    console.log(`  Total Size:       ${formatFileSize(stats.lua.totalSize + stats.xml.totalSize)}`);
+    console.log('');
+
+    // Lines of code
+    console.log(`${colors.bold}Lines of Code (Lua):${colors.reset}`);
+    console.log(`  Total Lines:      ${stats.lua.totalLines.toLocaleString()}`);
+    console.log(`  Code:             ${stats.lua.codeLines.toLocaleString()} (${Math.round(stats.lua.codeLines / stats.lua.totalLines * 100)}%)`);
+    console.log(`  Comments:         ${stats.lua.commentLines.toLocaleString()} (${Math.round(stats.lua.commentLines / stats.lua.totalLines * 100)}%)`);
+    console.log(`  Blank:            ${stats.lua.blankLines.toLocaleString()} (${Math.round(stats.lua.blankLines / stats.lua.totalLines * 100)}%)`);
+    console.log('');
+
+    // Component counts
+    console.log(`${colors.bold}Components:${colors.reset}`);
+    console.log(`  Dialogs:          ${stats.dialogs}`);
+    console.log(`  Events:           ${stats.events}`);
+    console.log(`  Managers:         ${stats.managers}`);
+    console.log(`  Extensions:       ${stats.extensions}`);
+    console.log('');
+
+    // Files by category
+    console.log(`${colors.bold}Files by Category:${colors.reset}`);
+    const sortedCategories = Object.entries(stats.lua.byCategory)
+        .filter(([_, data]) => data.files > 0)
+        .sort((a, b) => b[1].lines - a[1].lines);
+
+    for (const [category, data] of sortedCategories) {
+        const pct = Math.round(data.lines / stats.lua.codeLines * 100);
+        console.log(`  ${category.padEnd(22)} ${String(data.files).padStart(3)} files  ${String(data.lines.toLocaleString()).padStart(7)} lines (${pct}%)`);
+    }
+    console.log('');
+
+    // Largest files
+    console.log(`${colors.bold}Top 10 Largest Files:${colors.reset}`);
+    for (let i = 0; i < stats.lua.largestFiles.length; i++) {
+        const file = stats.lua.largestFiles[i];
+        console.log(`  ${String(i + 1).padStart(2)}. ${file.name.padEnd(40)} ${String(file.lines).padStart(5)} lines  ${formatFileSize(file.size).padStart(8)}`);
+    }
+}
+
+/**
+ * Gather mod-specific information from modDesc.xml and code
+ */
+function gatherModInfo(modRoot) {
+    const modInfo = {
+        name: 'Unknown',
+        version: 'Unknown',
+        author: 'Unknown',
+        title: 'Unknown',
+        description: '',
+        multiplayer: false,
+        translations: [],
+        inputActions: [],
+        storeItems: [],
+        specializations: {
+            vehicle: [],
+            placeable: []
+        },
+        vehicleTypes: [],
+        placeableTypes: [],
+        features: [],
+        crossModCompat: [],
+        settings: []
+    };
+
+    // Parse modDesc.xml
+    const modDescPath = path.join(modRoot, 'modDesc.xml');
+    if (fs.existsSync(modDescPath)) {
+        const content = fs.readFileSync(modDescPath, 'utf8');
+
+        // Basic info
+        const versionMatch = content.match(/<version>([^<]+)<\/version>/);
+        if (versionMatch) modInfo.version = versionMatch[1];
+
+        const authorMatch = content.match(/<author>([^<]+)<\/author>/);
+        if (authorMatch) modInfo.author = authorMatch[1];
+
+        const titleMatch = content.match(/<title>\s*<en>([^<]+)<\/en>/);
+        if (titleMatch) modInfo.title = titleMatch[1].replace(/&amp;/g, '&');
+
+        // Multiplayer support
+        modInfo.multiplayer = content.includes('multiplayer supported="true"');
+
+        // Input actions
+        const actionRegex = /<action name="([^"]+)"/g;
+        let actionMatch;
+        while ((actionMatch = actionRegex.exec(content)) !== null) {
+            modInfo.inputActions.push(actionMatch[1]);
+        }
+
+        // Store items
+        const storeRegex = /<storeItem xmlFilename="([^"]+)"/g;
+        let storeMatch;
+        while ((storeMatch = storeRegex.exec(content)) !== null) {
+            modInfo.storeItems.push(storeMatch[1]);
+        }
+
+        // Vehicle specializations
+        const vehSpecRegex = /<specializations>\s*([\s\S]*?)<\/specializations>/;
+        const vehSpecBlock = content.match(vehSpecRegex);
+        if (vehSpecBlock) {
+            const specRegex = /<specialization name="([^"]+)"/g;
+            let specMatch;
+            while ((specMatch = specRegex.exec(vehSpecBlock[1])) !== null) {
+                modInfo.specializations.vehicle.push(specMatch[1]);
+            }
+        }
+
+        // Placeable specializations
+        const placeSpecRegex = /<placeableSpecializations>\s*([\s\S]*?)<\/placeableSpecializations>/;
+        const placeSpecBlock = content.match(placeSpecRegex);
+        if (placeSpecBlock) {
+            const specRegex = /<specialization name="([^"]+)"/g;
+            let specMatch;
+            while ((specMatch = specRegex.exec(placeSpecBlock[1])) !== null) {
+                modInfo.specializations.placeable.push(specMatch[1]);
+            }
+        }
+
+        // Vehicle types
+        const vehTypeRegex = /<type name="([^"]+)"/g;
+        let vehTypeMatch;
+        while ((vehTypeMatch = vehTypeRegex.exec(content)) !== null) {
+            if (!modInfo.vehicleTypes.includes(vehTypeMatch[1])) {
+                modInfo.vehicleTypes.push(vehTypeMatch[1]);
+            }
+        }
+    }
+
+    // Count translations
+    const transDir = path.join(modRoot, 'translations');
+    if (fs.existsSync(transDir)) {
+        const transFiles = fs.readdirSync(transDir).filter(f => f.endsWith('.xml'));
+        for (const file of transFiles) {
+            const langMatch = file.match(/translation_(\w+)\.xml/);
+            if (langMatch) {
+                modInfo.translations.push(langMatch[1].toUpperCase());
+            }
+        }
+    }
+
+    // Detect features from code patterns
+    const featurePatterns = [
+        { pattern: /FinanceManager|FinanceDeal/g, feature: 'Vehicle/Equipment Financing', icon: '💰' },
+        { pattern: /LeaseDeal|LeaseVehicle/g, feature: 'Vehicle Leasing', icon: '📋' },
+        { pattern: /LandLeaseDeal|LandLeaseEvent/g, feature: 'Land Leasing', icon: '🏞️' },
+        { pattern: /CreditSystem|CreditScore/g, feature: 'Dynamic Credit Scoring (300-850)', icon: '📊' },
+        { pattern: /TakeLoanDialog|TakeLoanEvent/g, feature: 'Collateral-Based Cash Loans', icon: '🏦' },
+        { pattern: /UsedVehicleManager|UsedVehicleSearch/g, feature: 'Used Vehicle Marketplace', icon: '🚜' },
+        { pattern: /VehicleSaleManager|VehicleSaleListing/g, feature: 'Agent-Based Vehicle Sales', icon: '🏷️' },
+        { pattern: /NegotiationDialog|SellerResponseDialog/g, feature: 'Price Negotiation System', icon: '🤝' },
+        { pattern: /InspectionReport|VehicleInspection/g, feature: 'Vehicle Inspection Reports', icon: '🔍' },
+        { pattern: /RepairDialog|RepairVehicleEvent/g, feature: 'Partial Repair System (1-100%)', icon: '🔧' },
+        { pattern: /TiresDialog|MaintenanceTires/g, feature: 'Tire Replacement System', icon: '⚙️' },
+        { pattern: /FluidsDialog|MaintenanceFluids/g, feature: 'Fluid Service (Oil/Hydraulic)', icon: '🛢️' },
+        { pattern: /FieldServiceKit/g, feature: 'Field Service Kit (Roadside Repairs)', icon: '🧰' },
+        { pattern: /OBDScanner|DiagnosisData/g, feature: 'OBD Scanner Diagnostics', icon: '📟' },
+        { pattern: /MaintenanceReliability|MaintenanceEngine/g, feature: 'Component Reliability System', icon: '⚡' },
+        { pattern: /TradeInCalculations|tradeIn/gi, feature: 'Trade-In System', icon: '🔄' },
+        { pattern: /DepreciationCalculations/g, feature: 'Realistic Depreciation', icon: '📉' },
+        { pattern: /DifficultyScalingManager/g, feature: 'Difficulty-Based Pricing', icon: '⚖️' },
+        { pattern: /BankInterestManager/g, feature: 'Bank Interest on Cash', icon: '💵' },
+        { pattern: /PaymentTracker|PaymentHistory/g, feature: 'Payment History Tracking', icon: '📅' },
+        { pattern: /RepossessionDialog/g, feature: 'Vehicle Repossession System', icon: '🚨' },
+        { pattern: /FinanceManagerFrame/g, feature: 'ESC Menu Finance Manager', icon: '📱' },
+        { pattern: /FinancialDashboard/g, feature: 'Financial Dashboard', icon: '📈' }
+    ];
+
+    // Detect cross-mod compatibility
+    const crossModPatterns = [
+        { pattern: /RVB|RealisticVehicleBreakdown/gi, mod: 'FS25_RealisticVehicleBreakdown (RVB)', icon: '🔗' },
+        { pattern: /UYT|UsedYourTool/gi, mod: 'FS25_UsedYourTool (UYT)', icon: '🔗' },
+        { pattern: /ModCompatibility/g, mod: 'Generic Mod Compatibility Layer', icon: '🔌' }
+    ];
+
+    // Scan source files for features
+    const srcDir = path.join(modRoot, 'src');
+    if (fs.existsSync(srcDir)) {
+        const luaFiles = findFiles(srcDir, /\.lua$/);
+        const allContent = luaFiles.map(f => {
+            try { return fs.readFileSync(f, 'utf8'); }
+            catch (e) { return ''; }
+        }).join('\n');
+
+        // Detect features
+        for (const fp of featurePatterns) {
+            if (fp.pattern.test(allContent)) {
+                modInfo.features.push({ name: fp.feature, icon: fp.icon });
+            }
+            fp.pattern.lastIndex = 0; // Reset regex
+        }
+
+        // Detect cross-mod compatibility
+        for (const cm of crossModPatterns) {
+            if (cm.pattern.test(allContent)) {
+                modInfo.crossModCompat.push({ name: cm.mod, icon: cm.icon });
+            }
+            cm.pattern.lastIndex = 0;
+        }
+    }
+
+    // Count settings from UsedPlusSettings
+    const settingsPath = path.join(modRoot, 'src', 'settings', 'UsedPlusSettings.lua');
+    if (fs.existsSync(settingsPath)) {
+        const settingsContent = fs.readFileSync(settingsPath, 'utf8');
+        const settingRegex = /["'](\w+)["']\s*[=:]/g;
+        const defaultsMatch = settingsContent.match(/DEFAULTS\s*=\s*\{([\s\S]*?)\}/);
+        if (defaultsMatch) {
+            let settingMatch;
+            while ((settingMatch = settingRegex.exec(defaultsMatch[1])) !== null) {
+                if (!['true', 'false', 'nil'].includes(settingMatch[1])) {
+                    modInfo.settings.push(settingMatch[1]);
+                }
+            }
+        }
+    }
+
+    // Scan for console commands
+    modInfo.consoleCommands = [];
+    const mainPath = path.join(modRoot, 'src', 'main.lua');
+    if (fs.existsSync(mainPath)) {
+        const mainContent = fs.readFileSync(mainPath, 'utf8');
+        const cmdRegex = /addConsoleCommand\s*\(\s*"([^"]+)"\s*,\s*"([^"]+)"/g;
+        let cmdMatch;
+        while ((cmdMatch = cmdRegex.exec(mainContent)) !== null) {
+            modInfo.consoleCommands.push({
+                name: cmdMatch[1],
+                description: cmdMatch[2]
+            });
+        }
+    }
+
+    // Scan for vehicle metrics tracked (maintenance system)
+    modInfo.vehicleMetrics = [];
+    modInfo.malfunctions = [];
+
+    // Gather all maintenance-related content from main spec and modules
+    let maintContent = '';
+    const maintenancePath = path.join(modRoot, 'src', 'specializations', 'UsedPlusMaintenance.lua');
+    if (fs.existsSync(maintenancePath)) {
+        maintContent += fs.readFileSync(maintenancePath, 'utf8');
+    }
+
+    // Also scan maintenance modules
+    const maintModulesDir = path.join(modRoot, 'src', 'specializations', 'maintenance');
+    if (fs.existsSync(maintModulesDir)) {
+        const moduleFiles = fs.readdirSync(maintModulesDir).filter(f => f.endsWith('.lua'));
+        for (const file of moduleFiles) {
+            try {
+                maintContent += '\n' + fs.readFileSync(path.join(maintModulesDir, file), 'utf8');
+            } catch (e) {}
+        }
+    }
+
+    if (maintContent.length > 0) {
+
+        // Detect tracked metrics
+        const metricsPatterns = [
+            { pattern: /spec\.oilLevel/g, metric: 'Engine Oil Level', icon: '🛢️', unit: '0-100%' },
+            { pattern: /spec\.hydraulicFluidLevel/g, metric: 'Hydraulic Fluid Level', icon: '💧', unit: '0-100%' },
+            { pattern: /spec\.tireQuality/g, metric: 'Tire Quality Grade', icon: '⚙️', unit: '1-3' },
+            { pattern: /spec\.tireCondition/g, metric: 'Tire Condition', icon: '🔄', unit: '0-100%' },
+            { pattern: /spec\.operatingHours/g, metric: 'Operating Hours', icon: '⏱️', unit: 'hours' },
+            { pattern: /spec\.lastOilChange/g, metric: 'Last Oil Change', icon: '📅', unit: 'hours ago' },
+            { pattern: /spec\.lastHydraulicService/g, metric: 'Last Hydraulic Service', icon: '🔧', unit: 'hours ago' },
+            { pattern: /spec\.reliabilityScore/g, metric: 'Reliability Score', icon: '📊', unit: '0-100' },
+            { pattern: /spec\.engineTemperature/g, metric: 'Engine Temperature', icon: '🌡️', unit: '°C' },
+            { pattern: /spec\.engineHealth/g, metric: 'Engine Health', icon: '❤️', unit: '0-100%' },
+            { pattern: /spec\.steeringPlay/g, metric: 'Steering Play', icon: '🎯', unit: '0-100%' },
+            { pattern: /spec\.hasInspectionCache/g, metric: 'Inspection Cache', icon: '📋', unit: 'bool' },
+            { pattern: /spec\.purchaseAge/g, metric: 'Purchase Age', icon: '📆', unit: 'hours' },
+            { pattern: /spec\.oilServiceInterval/g, metric: 'Oil Service Interval', icon: '⏰', unit: 'hours' },
+            { pattern: /spec\.hydraulicServiceInterval/g, metric: 'Hydraulic Service Interval', icon: '⏰', unit: 'hours' }
+        ];
+
+        for (const mp of metricsPatterns) {
+            if (mp.pattern.test(maintContent)) {
+                modInfo.vehicleMetrics.push({ name: mp.metric, icon: mp.icon, unit: mp.unit });
+            }
+            mp.pattern.lastIndex = 0;
+        }
+
+        // Detect malfunctions (based on actual spec variables in UsedPlusMaintenance)
+        const malfunctionPatterns = [
+            { pattern: /spec\.isStalled/g, malf: 'Engine Stall', icon: '🛑', desc: 'Engine stops unexpectedly' },
+            { pattern: /spec\.isCutout/g, malf: 'Electrical Cutout', icon: '⚡', desc: 'Electrical system failure' },
+            { pattern: /spec\.isOverheated/g, malf: 'Overheating', icon: '🔥', desc: 'Engine runs too hot' },
+            { pattern: /spec\.isDrifting/g, malf: 'Steering Drift', icon: '↔️', desc: 'Vehicle pulls to one side' },
+            { pattern: /spec\.hasFlatTire/g, malf: 'Flat Tire', icon: '🎈', desc: 'Tire puncture/blowout' },
+            { pattern: /spec\.hasOilLeak/g, malf: 'Oil Leak', icon: '🛢️', desc: 'Losing engine oil' },
+            { pattern: /spec\.hasHydraulicLeak/g, malf: 'Hydraulic Leak', icon: '💧', desc: 'Losing hydraulic fluid' },
+            { pattern: /spec\.hasFuelLeak/g, malf: 'Fuel Leak', icon: '⛽', desc: 'Losing fuel' },
+            { pattern: /spec\.engineSeized/g, malf: 'Engine Seizure', icon: '💀', desc: 'Permanent engine damage' }
+        ];
+
+        for (const mf of malfunctionPatterns) {
+            if (mf.pattern.test(maintContent)) {
+                modInfo.malfunctions.push({ name: mf.malf, icon: mf.icon, description: mf.desc });
+            }
+            mf.pattern.lastIndex = 0;
+        }
+    }
+
+    // Get maintenance module names
+    const maintModulesDirForNames = path.join(modRoot, 'src', 'specializations', 'maintenance');
+    if (fs.existsSync(maintModulesDirForNames)) {
+        modInfo.maintenanceModules = fs.readdirSync(maintModulesDirForNames)
+            .filter(f => f.endsWith('.lua'))
+            .map(f => f.replace('.lua', '').replace('Maintenance', ''));
+    } else {
+        modInfo.maintenanceModules = [];
+    }
+
+    // Scan for vanilla hooks (Utils.appendedFunction / prependedFunction)
+    modInfo.vanillaHooks = [];
+    modInfo.eventSubscriptions = [];
+
+    const srcDirForHooks = path.join(modRoot, 'src');
+    if (fs.existsSync(srcDirForHooks)) {
+        const luaFilesForHooks = findFiles(srcDirForHooks, /\.lua$/);
+
+        for (const file of luaFilesForHooks) {
+            try {
+                const content = fs.readFileSync(file, 'utf8');
+                const relPath = path.relative(modRoot, file).replace(/\\/g, '/');
+                const fileName = path.basename(file, '.lua');
+
+                // Find Utils.appendedFunction hooks
+                const appendRegex = /(\w+(?:\.\w+)*)\s*=\s*Utils\.appendedFunction\s*\(\s*(\w+(?:\.\w+)*)/g;
+                let match;
+                while ((match = appendRegex.exec(content)) !== null) {
+                    const target = match[2];
+                    // Skip if target matches the first part (self-reference)
+                    if (!target.startsWith(fileName)) {
+                        modInfo.vanillaHooks.push({
+                            type: 'append',
+                            target: target,
+                            source: relPath
+                        });
+                    }
+                }
+
+                // Find Utils.prependedFunction hooks
+                const prependRegex = /(\w+(?:\.\w+)*)\s*=\s*Utils\.prependedFunction\s*\(\s*(\w+(?:\.\w+)*)/g;
+                while ((match = prependRegex.exec(content)) !== null) {
+                    const target = match[2];
+                    if (!target.startsWith(fileName)) {
+                        modInfo.vanillaHooks.push({
+                            type: 'prepend',
+                            target: target,
+                            source: relPath
+                        });
+                    }
+                }
+
+                // Find g_messageCenter:subscribe
+                const subscribeRegex = /g_messageCenter:subscribe\s*\(\s*MessageType\.(\w+)/g;
+                while ((match = subscribeRegex.exec(content)) !== null) {
+                    const existing = modInfo.eventSubscriptions.find(e => e.event === match[1] && e.source === relPath);
+                    if (!existing) {
+                        modInfo.eventSubscriptions.push({
+                            event: match[1],
+                            source: relPath
+                        });
+                    }
+                }
+            } catch (e) {}
+        }
+
+        // Remove duplicates from hooks (same target might be hooked in multiple places)
+        const uniqueHooks = [];
+        const seenHooks = new Set();
+        for (const hook of modInfo.vanillaHooks) {
+            const key = `${hook.type}:${hook.target}`;
+            if (!seenHooks.has(key)) {
+                seenHooks.add(key);
+                uniqueHooks.push(hook);
+            }
+        }
+        modInfo.vanillaHooks = uniqueHooks;
+    }
+
+    return modInfo;
+}
+
+/**
+ * Print mod-specific information
+ */
+function printModInfo(modInfo, stats) {
+    console.log(`\n${colors.bold}${colors.cyan}=== Mod Information ===${colors.reset}\n`);
+
+    // Header
+    console.log(`${colors.bold}${modInfo.title}${colors.reset}`);
+    console.log(`  Version:          ${modInfo.version}`);
+    console.log(`  Author:           ${modInfo.author}`);
+    console.log(`  Multiplayer:      ${modInfo.multiplayer ? colors.green + 'Supported' + colors.reset : colors.red + 'No' + colors.reset}`);
+    console.log('');
+
+    // Features
+    console.log(`${colors.bold}Features Implemented (${modInfo.features.length}):${colors.reset}`);
+    const featureCols = 2;
+    const featureRows = Math.ceil(modInfo.features.length / featureCols);
+    for (let row = 0; row < featureRows; row++) {
+        let line = '';
+        for (let col = 0; col < featureCols; col++) {
+            const idx = row + col * featureRows;
+            if (idx < modInfo.features.length) {
+                const f = modInfo.features[idx];
+                line += `  ${f.icon} ${f.name.padEnd(35)}`;
+            }
+        }
+        console.log(line);
+    }
+    console.log('');
+
+    // Cross-mod compatibility
+    if (modInfo.crossModCompat.length > 0) {
+        console.log(`${colors.bold}Cross-Mod Compatibility (${modInfo.crossModCompat.length}):${colors.reset}`);
+        for (const cm of modInfo.crossModCompat) {
+            console.log(`  ${cm.icon} ${cm.name}`);
+        }
+        console.log('');
+    }
+
+    // Translations
+    console.log(`${colors.bold}Language Support (${modInfo.translations.length}):${colors.reset}`);
+    console.log(`  ${modInfo.translations.join(', ')}`);
+    console.log('');
+
+    // Input bindings
+    if (modInfo.inputActions.length > 0) {
+        console.log(`${colors.bold}Keyboard Shortcuts (${modInfo.inputActions.length}):${colors.reset}`);
+        for (const action of modInfo.inputActions) {
+            // Clean up action name for display
+            const displayName = action.replace('USEDPLUS_', '').replace(/_/g, ' ');
+            console.log(`  ⌨️  ${displayName}`);
+        }
+        console.log('');
+    }
+
+    // Store items
+    if (modInfo.storeItems.length > 0) {
+        console.log(`${colors.bold}Store Items (${modInfo.storeItems.length}):${colors.reset}`);
+        for (const item of modInfo.storeItems) {
+            const itemName = path.basename(item, '.xml');
+            console.log(`  🛒 ${itemName}`);
+        }
+        console.log('');
+    }
+
+    // Specializations
+    const totalSpecs = modInfo.specializations.vehicle.length + modInfo.specializations.placeable.length;
+    if (totalSpecs > 0) {
+        console.log(`${colors.bold}Custom Specializations (${totalSpecs}):${colors.reset}`);
+        for (const spec of modInfo.specializations.vehicle) {
+            console.log(`  🚜 ${spec} (Vehicle)`);
+        }
+        for (const spec of modInfo.specializations.placeable) {
+            console.log(`  🏭 ${spec} (Placeable)`);
+        }
+        console.log('');
+    }
+
+    // Settings count
+    if (modInfo.settings.length > 0) {
+        console.log(`${colors.bold}Configurable Settings:${colors.reset} ${modInfo.settings.length} options`);
+        console.log('');
+    }
+
+    // Console commands
+    if (modInfo.consoleCommands && modInfo.consoleCommands.length > 0) {
+        console.log(`${colors.bold}Console Commands (${modInfo.consoleCommands.length}):${colors.reset}`);
+        for (const cmd of modInfo.consoleCommands) {
+            console.log(`  💻 ${colors.cyan}${cmd.name}${colors.reset}`);
+            console.log(`      ${cmd.description}`);
+        }
+        console.log('');
+    }
+
+    // Vanilla hooks
+    if (modInfo.vanillaHooks && modInfo.vanillaHooks.length > 0) {
+        console.log(`${colors.bold}${colors.red}=== Vanilla Game Hooks ===${colors.reset}\n`);
+
+        // Group by class
+        const hooksByClass = {};
+        for (const hook of modInfo.vanillaHooks) {
+            const parts = hook.target.split('.');
+            const className = parts[0];
+            if (!hooksByClass[className]) {
+                hooksByClass[className] = [];
+            }
+            hooksByClass[className].push(hook);
+        }
+
+        console.log(`${colors.bold}Hooked Functions (${modInfo.vanillaHooks.length}):${colors.reset}`);
+        for (const [className, hooks] of Object.entries(hooksByClass).sort()) {
+            console.log(`  ${colors.yellow}${className}${colors.reset}`);
+            for (const hook of hooks) {
+                const funcName = hook.target.split('.').slice(1).join('.');
+                const hookType = hook.type === 'prepend' ? '⬆️ PRE' : '⬇️ POST';
+                console.log(`    ${hookType}  ${funcName}`);
+            }
+        }
+        console.log('');
+
+        // Event subscriptions
+        if (modInfo.eventSubscriptions && modInfo.eventSubscriptions.length > 0) {
+            console.log(`${colors.bold}Event Subscriptions (${modInfo.eventSubscriptions.length}):${colors.reset}`);
+            const eventGroups = {};
+            for (const sub of modInfo.eventSubscriptions) {
+                if (!eventGroups[sub.event]) {
+                    eventGroups[sub.event] = [];
+                }
+                const shortSource = sub.source.split('/').pop();
+                if (!eventGroups[sub.event].includes(shortSource)) {
+                    eventGroups[sub.event].push(shortSource);
+                }
+            }
+            for (const [event, sources] of Object.entries(eventGroups).sort()) {
+                console.log(`  📡 MessageType.${event}`);
+                console.log(`      → ${sources.join(', ')}`);
+            }
+            console.log('');
+        }
+    }
+
+    // Vehicle Maintenance System
+    if ((modInfo.vehicleMetrics && modInfo.vehicleMetrics.length > 0) ||
+        (modInfo.malfunctions && modInfo.malfunctions.length > 0)) {
+        console.log(`${colors.bold}${colors.yellow}=== Vehicle Maintenance System ===${colors.reset}\n`);
+
+        // Maintenance modules
+        if (modInfo.maintenanceModules && modInfo.maintenanceModules.length > 0) {
+            console.log(`${colors.bold}Maintenance Modules (${modInfo.maintenanceModules.length}):${colors.reset}`);
+            console.log(`  ${modInfo.maintenanceModules.join(', ')}`);
+            console.log('');
+        }
+
+        // Vehicle metrics
+        if (modInfo.vehicleMetrics && modInfo.vehicleMetrics.length > 0) {
+            console.log(`${colors.bold}Vehicle Metrics Tracked (${modInfo.vehicleMetrics.length}):${colors.reset}`);
+            for (const m of modInfo.vehicleMetrics) {
+                console.log(`  ${m.icon} ${m.name.padEnd(28)} (${m.unit})`);
+            }
+            console.log('');
+        }
+
+        // Malfunctions
+        if (modInfo.malfunctions && modInfo.malfunctions.length > 0) {
+            console.log(`${colors.bold}Malfunction Events (${modInfo.malfunctions.length}):${colors.reset}`);
+            for (const mf of modInfo.malfunctions) {
+                console.log(`  ${mf.icon} ${mf.name.padEnd(20)} - ${mf.description}`);
+            }
+            console.log('');
+        }
+    }
+
+    // Quick stats summary
+    console.log(`${colors.bold}Quick Stats:${colors.reset}`);
+    console.log(`  📁 ${stats.lua.total} Lua files | ${stats.xml.total} XML files`);
+    console.log(`  📝 ${stats.lua.codeLines.toLocaleString()} lines of code | ${stats.lua.commentLines.toLocaleString()} comments`);
+    console.log(`  🖥️  ${stats.dialogs} dialogs | ${stats.events} event types | ${stats.managers} managers`);
+    console.log(`  💾 ${formatFileSize(stats.lua.totalSize + stats.xml.totalSize)} total size`);
+}
+
+/**
+ * Main function
+ */
+function main() {
+    const args = process.argv.slice(2);
+    const verbose = args.includes('--verbose') || args.includes('-v');
+    const checkFunctions = args.includes('--check-functions') || args.includes('-f');
+
+    console.log(`\n${colors.bold}${colors.cyan}=== FS25_UsedPlus Unused Code Scanner ===${colors.reset}\n`);
+
+    const modRoot = getModRoot();
+    console.log(`Mod root: ${modRoot}\n`);
+
+    let issuesFound = 0;
+
+    // === Check 1: Unregistered Lua files ===
+    console.log(`${colors.bold}[1] Checking for unregistered Lua files...${colors.reset}`);
+    const registered = parseModDescSources(modRoot);
+    const allLua = findAllLuaFiles(modRoot);
+
+    const unregistered = [...allLua].filter(f => !registered.has(f));
+    if (unregistered.length > 0) {
+        console.log(`${colors.yellow}  Found ${unregistered.length} unregistered file(s):${colors.reset}`);
+        for (const f of unregistered.sort()) {
+            console.log(`    - ${f}`);
+            issuesFound++;
+        }
+    } else {
+        console.log(`${colors.green}  All Lua files are registered in modDesc.xml${colors.reset}`);
+    }
+
+    // === Check 2: Orphaned dialogs ===
+    console.log(`\n${colors.bold}[2] Checking for orphaned dialogs...${colors.reset}`);
+    const dialogs = findAllDialogs(modRoot);
+    const orphanedDialogs = [];
+
+    for (const [dialogName, files] of Object.entries(dialogs)) {
+        const refs = searchDialogReferences(modRoot, dialogName);
+        if (refs.length === 0) {
+            orphanedDialogs.push({ name: dialogName, ...files });
+        }
+    }
+
+    if (orphanedDialogs.length > 0) {
+        console.log(`${colors.yellow}  Found ${orphanedDialogs.length} potentially orphaned dialog(s):${colors.reset}`);
+        for (const dialog of orphanedDialogs) {
+            console.log(`    - ${dialog.name}`);
+            if (dialog.lua) console.log(`        Lua: ${path.relative(modRoot, dialog.lua)}`);
+            if (dialog.xml) console.log(`        XML: ${path.relative(modRoot, dialog.xml)}`);
+            issuesFound++;
+        }
+    } else {
+        console.log(`${colors.green}  All dialogs appear to be in use${colors.reset}`);
+    }
+
+    // === Check 3: Mismatched dialog pairs ===
+    console.log(`\n${colors.bold}[3] Checking for mismatched dialog pairs...${colors.reset}`);
+    const mismatched = [];
+
+    for (const [dialogName, files] of Object.entries(dialogs)) {
+        if (files.lua && !files.xml) {
+            mismatched.push({ name: dialogName, issue: 'Missing XML' });
+        } else if (files.xml && !files.lua) {
+            mismatched.push({ name: dialogName, issue: 'Missing Lua' });
+        }
+    }
+
+    if (mismatched.length > 0) {
+        console.log(`${colors.yellow}  Found ${mismatched.length} mismatched pair(s):${colors.reset}`);
+        for (const item of mismatched) {
+            console.log(`    - ${item.name}: ${item.issue}`);
+            issuesFound++;
+        }
+    } else {
+        console.log(`${colors.green}  All dialogs have matching Lua/XML pairs${colors.reset}`);
+    }
+
+    // === Summary ===
+    console.log(`\n${colors.bold}${'='.repeat(50)}${colors.reset}`);
+    if (issuesFound > 0) {
+        console.log(`${colors.yellow}Found ${issuesFound} potential issue(s) to review${colors.reset}`);
+    } else {
+        console.log(`${colors.green}No issues found!${colors.reset}`);
+    }
+
+    // === Mod Info & Statistics ===
+    const stats = gatherStatistics(modRoot);
+    const modInfo = gatherModInfo(modRoot);
+    printModInfo(modInfo, stats);
+    printStatistics(stats);
+
+    console.log(`\n${colors.cyan}Options:${colors.reset}`);
+    console.log('  --verbose, -v          Show more details');
+    console.log('  --check-functions, -f  Check for unused functions (not yet implemented)');
+
+    return issuesFound;
+}
+
+// Run
+process.exit(main());

--- a/tools/run_all_checks.bat
+++ b/tools/run_all_checks.bat
@@ -1,0 +1,37 @@
+@echo off
+REM ================================================================
+REM FS25_RandomWorldEvents Validation Suite
+REM Run this before testing in-game or releasing
+REM ================================================================
+
+echo.
+echo ========================================
+echo   FS25_RandomWorldEvents Validation Suite
+echo ========================================
+echo.
+
+cd /d "%~dp0"
+
+echo Running static analysis...
+echo.
+powershell -ExecutionPolicy Bypass -File validate_mod.ps1
+set VALIDATE_RESULT=%ERRORLEVEL%
+
+echo.
+echo ========================================
+echo.
+echo To analyze game logs after testing, run:
+echo   powershell -ExecutionPolicy Bypass -File extract_log_errors.ps1
+echo.
+echo ========================================
+echo.
+
+REM Summarize
+if %VALIDATE_RESULT% NEQ 0 (
+    echo [REVIEW] Static analysis found issues to review
+) else (
+    echo [PASSED] Static analysis - no errors found
+)
+
+echo.
+pause

--- a/tools/test_global_leaks.lua
+++ b/tools/test_global_leaks.lua
@@ -1,0 +1,64 @@
+--[[
+    Test script to demonstrate global variable leaks
+    Run with: lua test_global_leaks.lua
+]]
+
+print("=== GLOBAL LEAK DEMONSTRATION ===\n")
+
+-- Simulate the buggy pattern
+function buggyRepairEvent(farmId, vehicleId, component, cost)
+    component = component or "all"
+    cost = cost or 0  -- BUG: Creates global!
+
+    print(string.format("  Repair: farmId=%d, cost=%d", farmId, cost))
+    return cost
+end
+
+-- Simulate the fixed pattern
+function fixedRepairEvent(farmId, vehicleId, component, cost)
+    local component = component or "all"
+    local cost = cost or 0  -- Safe: Local
+
+    print(string.format("  Repair: farmId=%d, cost=%d", farmId, cost))
+    return cost
+end
+
+print("--- BUGGY VERSION ---")
+print("Call 1: cost=5000")
+buggyRepairEvent(1, 123, "engine", 5000)
+print(string.format("Global 'cost' after call 1: %s\n", tostring(cost)))
+
+print("Call 2: cost=nil (should default to 0)")
+buggyRepairEvent(2, 456, "engine", nil)
+print(string.format("Global 'cost' after call 2: %s\n", tostring(cost)))
+
+print("Call 3: cost=0 explicitly")
+buggyRepairEvent(3, 789, "engine", 0)
+print(string.format("Global 'cost' after call 3: %s\n", tostring(cost)))
+
+-- Reset global
+cost = nil
+
+print("\n--- FIXED VERSION ---")
+print("Call 1: cost=5000")
+fixedRepairEvent(1, 123, "engine", 5000)
+print(string.format("Global 'cost' after call 1: %s\n", tostring(cost)))
+
+print("Call 2: cost=nil (should default to 0)")
+fixedRepairEvent(2, 456, "engine", nil)
+print(string.format("Global 'cost' after call 2: %s\n", tostring(cost)))
+
+print("Call 3: cost=0 explicitly")
+fixedRepairEvent(3, 789, "engine", 0)
+print(string.format("Global 'cost' after call 3: %s\n", tostring(cost)))
+
+print("\n=== EXPECTED OUTPUT ===")
+print("Buggy version: Global 'cost' should leak (5000, then 0)")
+print("Fixed version: Global 'cost' should stay nil")
+
+print("\n=== MULTIPLAYER SCENARIO ===")
+print("If two clients call buggyRepairEvent() with different costs,")
+print("the global 'cost' will persist between calls, causing:")
+print("  1. Client A charges $5000 (correct)")
+print("  2. Client B charges $5000 (WRONG - should be $0)")
+print("  3. Money mysteriously disappears!")

--- a/tools/validate_mod.ps1
+++ b/tools/validate_mod.ps1
@@ -1,0 +1,318 @@
+<#
+.SYNOPSIS
+    FS25_RandomWorldEvents Mod Validator (PowerShell version)
+    Static analysis tool to catch common errors before loading in-game.
+
+.DESCRIPTION
+    Performs the following checks:
+    - Lua pitfall detection (goto, os.time, etc.)
+    - XML well-formedness
+    - Callback cross-reference (XML onClick -> Lua function)
+    - Translation key validation
+    - modDesc.xml source file validation
+    - Debug code detection
+
+.EXAMPLE
+    .\validate_mod.ps1
+
+.EXAMPLE
+    .\validate_mod.ps1 -Verbose
+#>
+
+param(
+    [switch]$Verbose
+)
+
+# Get mod path (script is in tools/ subdirectory)
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ModPath = Split-Path -Parent $ScriptDir
+
+# Validation results
+$Errors = @()
+$Warnings = @()
+
+function Add-Error {
+    param([string]$File, [string]$Category, [int]$Line, [string]$Message)
+    $script:Errors += [PSCustomObject]@{
+        File = $File
+        Category = $Category
+        Line = $Line
+        Message = $Message
+    }
+}
+
+function Add-Warning {
+    param([string]$File, [string]$Category, [int]$Line, [string]$Message)
+    $script:Warnings += [PSCustomObject]@{
+        File = $File
+        Category = $Category
+        Line = $Line
+        Message = $Message
+    }
+}
+
+function Write-Header {
+    param([string]$Text)
+    Write-Host "`n$('=' * 50)" -ForegroundColor Cyan
+    Write-Host $Text -ForegroundColor Cyan
+    Write-Host "$('=' * 50)" -ForegroundColor Cyan
+}
+
+function Write-Check {
+    param([string]$Text)
+    Write-Host "  Checking: $Text..." -ForegroundColor Blue
+}
+
+# Verify mod path
+if (-not (Test-Path (Join-Path $ModPath "modDesc.xml"))) {
+    Write-Host "Error: modDesc.xml not found at $ModPath" -ForegroundColor Red
+    exit 1
+}
+
+Write-Header "FS25_RandomWorldEvents Mod Validator"
+Write-Host "Mod Path: $ModPath" -ForegroundColor Gray
+Write-Host "Time: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')" -ForegroundColor Gray
+
+# ============================================================
+# Phase 1: Collect Lua function names
+# ============================================================
+Write-Host "`nPhase 1: Collecting data..." -ForegroundColor Blue
+
+$LuaFunctions = @{}
+$LuaFiles = Get-ChildItem -Path $ModPath -Filter "*.lua" -Recurse
+
+Write-Host "  Found $($LuaFiles.Count) Lua files" -ForegroundColor Gray
+
+foreach ($file in $LuaFiles) {
+    $RelPath = $file.FullName.Substring($ModPath.Length + 1)
+    $content = Get-Content $file.FullName -Raw -ErrorAction SilentlyContinue
+    if (-not $content) { continue }
+
+    $lines = $content -split "`n"
+    $LuaFunctions[$RelPath] = @()
+
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        $line = $lines[$i]
+        $lineNum = $i + 1
+
+        # Find function definitions
+        if ($line -match 'function\s+(?:\w+[:.])?([\w]+)\s*\(') {
+            $LuaFunctions[$RelPath] += $matches[1]
+        }
+
+        # Skip comment lines and comment blocks
+        $trimmedLine = $line.Trim()
+        $isComment = $trimmedLine.StartsWith('--') -or $trimmedLine.StartsWith('Note:')
+
+        # Check for Lua pitfalls (only in actual code, not comments)
+        # Only check patterns that indicate actual code issues
+        $pitfalls = @(
+            @{Pattern = '^\s*goto\s+\w'; Message = "Lua 5.1 does not support 'goto' (FS25 uses Lua 5.1)"},
+            @{Pattern = '::\w+::'; Message = "Lua 5.1 does not support labels '::label::'"},
+            @{Pattern = '=\s*os\.time\s*\('; Message = "os.time() not available - use g_currentMission.time"},
+            @{Pattern = '=\s*os\.date\s*\('; Message = "os.date() not available - use g_currentMission.environment"},
+            @{Pattern = 'setTextColorByName\s*\('; Message = "setTextColorByName() doesn't exist - use setTextColor(r,g,b,a)"},
+            # Only flag DialogElement class extension, not constant usage like DialogElement.TYPE_INFO
+            @{Pattern = 'DialogElement\s*[.:]new\s*\(|extends.*DialogElement'; Message = "DialogElement is deprecated - use MessageDialog pattern"}
+        )
+
+        if (-not $isComment) {
+            foreach ($pitfall in $pitfalls) {
+                if ($line -match $pitfall.Pattern) {
+                    Add-Error -File $RelPath -Category "LUA_PITFALL" -Line $lineNum -Message $pitfall.Message
+                }
+            }
+        }
+
+        # Check for debug code (skip comments and the core logging file itself)
+        if (-not $isComment -and $line -match '\bprint\s*\(' -and $line -notmatch 'RandomWorldEvents\.log' -and $RelPath -notmatch 'RandomWorldEventsCore\.lua') {
+            Add-Warning -File $RelPath -Category "DEBUG_CODE" -Line $lineNum -Message "Raw print() - use RWE.log* instead"
+        }
+    }
+}
+
+# Build flat list of all function names
+$AllFunctions = @()
+foreach ($funcs in $LuaFunctions.Values) {
+    $AllFunctions += $funcs
+}
+$AllFunctions = $AllFunctions | Select-Object -Unique
+Write-Host "  Found $($AllFunctions.Count) Lua functions" -ForegroundColor Gray
+
+# ============================================================
+# Phase 2: Collect XML callbacks and validate
+# ============================================================
+$XmlFiles = Get-ChildItem -Path $ModPath -Filter "*.xml" -Recurse | Where-Object { $_.Name -notmatch 'modDesc|translation' }
+
+Write-Host "  Found $($XmlFiles.Count) GUI XML files" -ForegroundColor Gray
+
+$CallbackAttrs = @('onClick', 'onOpen', 'onClose', 'onCreate', 'onHighlight', 'onHighlightRemove',
+                   'onFocus', 'onFocusLeave', 'onChange', 'onCheckedChanged', 'onSelectionChanged')
+
+foreach ($file in $XmlFiles) {
+    $RelPath = $file.FullName.Substring($ModPath.Length + 1)
+
+    try {
+        $content = Get-Content $file.FullName -Raw -ErrorAction Stop
+        $lines = $content -split "`n"
+
+        for ($i = 0; $i -lt $lines.Count; $i++) {
+            $line = $lines[$i]
+            $lineNum = $i + 1
+
+            foreach ($attr in $CallbackAttrs) {
+                if ($line -match "$attr=`"(\w+)`"") {
+                    $callback = $matches[1]
+                    # Skip base class callbacks
+                    if ($callback -in @('onOpen', 'onClose', 'onCreate', 'superClass')) {
+                        continue
+                    }
+                    if ($callback -notin $AllFunctions) {
+                        Add-Error -File $RelPath -Category "MISSING_CALLBACK" -Line $lineNum -Message "$attr=`"$callback`" - function not found in Lua"
+                    }
+                }
+            }
+        }
+
+        # Validate XML syntax
+        try {
+            [xml]$xml = $content
+        } catch {
+            Add-Error -File $RelPath -Category "XML_PARSE" -Line 0 -Message "XML parse error: $($_.Exception.Message)"
+        }
+
+    } catch {
+        Add-Error -File $RelPath -Category "FILE_READ" -Line 0 -Message "Could not read file: $($_.Exception.Message)"
+    }
+}
+
+# ============================================================
+# Phase 3: Translation key validation
+# ============================================================
+Write-Host "`nPhase 2: Cross-reference validation..." -ForegroundColor Blue
+
+$TransDir = Join-Path $ModPath "translations"
+$TransKeys = @()
+
+$EnFile = Join-Path $TransDir "translation_en.xml"
+if (Test-Path $EnFile) {
+    $enContent = Get-Content $EnFile -Raw
+    # Match both <e k="key" and <text name="key" formats
+    $keyMatches = [regex]::Matches($enContent, '<e\s+k="(\w+)"')
+    foreach ($match in $keyMatches) {
+        $TransKeys += $match.Groups[1].Value
+    }
+    $textMatches = [regex]::Matches($enContent, '<text\s+name="(\w+)"')
+    foreach ($match in $textMatches) {
+        $TransKeys += $match.Groups[1].Value
+    }
+    Write-Host "  Found $($TransKeys.Count) translation keys" -ForegroundColor Gray
+}
+
+# Check for missing translation keys in Lua files
+# Only flag rwe_* keys as missing (base game keys are expected to be in game's i18n)
+foreach ($file in $LuaFiles) {
+    $RelPath = $file.FullName.Substring($ModPath.Length + 1)
+    $content = Get-Content $file.FullName -Raw -ErrorAction SilentlyContinue
+    if (-not $content) { continue }
+
+    $lines = $content -split "`n"
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        $line = $lines[$i]
+        $lineNum = $i + 1
+
+        # Skip comment lines
+        $trimmedLine = $line.Trim()
+        if ($trimmedLine.StartsWith('--')) { continue }
+
+        $keyMatches = [regex]::Matches($line, 'getText\s*\(\s*["''](\w+)["'']')
+        foreach ($match in $keyMatches) {
+            $key = $match.Groups[1].Value
+            # Only flag rwe_* keys as errors (base game keys are assumed to exist)
+            # Skip keys ending with _ (dynamic key construction like "rwe_fluid_" .. fluidType)
+            if ($key.StartsWith('rwe_') -and -not $key.EndsWith('_') -and $key -notin $TransKeys) {
+                Add-Error -File $RelPath -Category "MISSING_TRANSLATION" -Line $lineNum -Message "Translation key $key not found in translation_en.xml"
+            }
+        }
+    }
+}
+
+# ============================================================
+# Phase 4: modDesc validation
+# ============================================================
+Write-Host "`nPhase 3: modDesc validation..." -ForegroundColor Blue
+
+$ModDescPath = Join-Path $ModPath "modDesc.xml"
+$modDescContent = Get-Content $ModDescPath -Raw
+
+# Check source files exist
+$sourceMatches = [regex]::Matches($modDescContent, '<sourceFile\s+filename="([^"]+)"')
+foreach ($match in $sourceMatches) {
+    $srcFile = $match.Groups[1].Value
+    if (-not (Test-Path (Join-Path $ModPath $srcFile))) {
+        Add-Error -File "modDesc.xml" -Category "MISSING_SOURCE" -Line 0 -Message "sourceFile '$srcFile' does not exist"
+    }
+}
+
+# ============================================================
+# Print Results
+# ============================================================
+Write-Header "Validation Results"
+
+# Group errors by category
+$ErrorsByCategory = $Errors | Group-Object -Property Category
+
+if ($Errors.Count -gt 0) {
+    Write-Host "`nERRORS: $($Errors.Count)" -ForegroundColor Red -BackgroundColor Black
+
+    foreach ($group in $ErrorsByCategory) {
+        Write-Host "`n  [$($group.Name)] ($($group.Count) issues)" -ForegroundColor Red
+        $group.Group | Select-Object -First 10 | ForEach-Object {
+            $lineStr = if ($_.Line -gt 0) { ":$($_.Line)" } else { "" }
+            Write-Host "    $($_.File)$lineStr : $($_.Message)" -ForegroundColor Red
+        }
+        if ($group.Count -gt 10) {
+            Write-Host "    ... and $($group.Count - 10) more" -ForegroundColor Red
+        }
+    }
+} else {
+    Write-Host "`nERRORS: 0" -ForegroundColor Green
+}
+
+$WarningsByCategory = $Warnings | Group-Object -Property Category
+
+if ($Warnings.Count -gt 0) {
+    Write-Host "`nWARNINGS: $($Warnings.Count)" -ForegroundColor Yellow
+
+    foreach ($group in $WarningsByCategory) {
+        Write-Host "`n  [$($group.Name)] ($($group.Count) issues)" -ForegroundColor Yellow
+        $group.Group | Select-Object -First 10 | ForEach-Object {
+            $lineStr = if ($_.Line -gt 0) { ":$($_.Line)" } else { "" }
+            Write-Host "    $($_.File)$lineStr : $($_.Message)" -ForegroundColor Yellow
+        }
+        if ($group.Count -gt 10) {
+            Write-Host "    ... and $($group.Count - 10) more" -ForegroundColor Yellow
+        }
+    }
+} else {
+    Write-Host "`nWARNINGS: 0" -ForegroundColor Green
+}
+
+# Summary
+Write-Host "`n$('=' * 50)" -ForegroundColor Cyan
+if ($Errors.Count -eq 0 -and $Warnings.Count -eq 0) {
+    Write-Host "All checks passed!" -ForegroundColor Green
+} else {
+    Write-Host "Total: $($Errors.Count) errors, $($Warnings.Count) warnings" -ForegroundColor White
+    if ($Errors.Count -gt 0) {
+        Write-Host "Fix errors before loading in-game!" -ForegroundColor Red
+    }
+}
+Write-Host "$('=' * 50)`n" -ForegroundColor Cyan
+
+# Exit code
+if ($Errors.Count -gt 0) {
+    exit 1
+} else {
+    exit 0
+}


### PR DESCRIPTION
## Summary
- Fixes contract/event-fail-on-reload bug — `EVENT_STATE` (activeEvent, duration, cooldown) was never written to XML. Now saves remaining time as offset values and restores them in `loadMission00Finished` when `g_currentMission.time` is valid.
- Closes #18 — Applies German translation from @Phasen-kasper (98 strings) plus manual fixes for 2 missed keys ("Debug", "Häufigkeit (1-10)").

## Test plan
- [ ] Trigger an event via `rweTest`, save game, reload — confirm event resumes with correct remaining time in HUD
- [ ] Confirm cooldown survives reload (no immediate re-trigger after reload)
- [ ] Set game language to German — confirm no `[EN]` placeholder strings in UI