### PR TITLE
fix(hud): the event HUD stands down while the settings panel is open

### DIFF
--- a/integrations/RWEMasterHUDBridge.lua
+++ b/integrations/RWEMasterHUDBridge.lua
@@ -41,14 +41,27 @@ function RWEMasterHUDBridge.drawStack()
     local mgr = g_RandomWorldEvents
     if mgr == nil then return end
 
-    -- Event HUD only draws when no GUI/menu is open.
-    if g_gui and not g_gui:getIsGuiVisible() then
+    -- THE SETTINGS PANEL OWNS THE SCREEN WHILE IT IS OPEN, so the event HUD
+    -- stands down for it exactly as it already stands down for a GUI menu.
+    --
+    -- A panel background is an OVERLAY, and an overlay does not cover text that
+    -- was already rendered underneath it. The event HUD draws first, so its text
+    -- read straight THROUGH the panel. A HUD cannot be hidden by drawing the
+    -- panel on top of it; it has to not draw.
+    --
+    -- isOpen is a FIELD on this panel, not a method (RWESettingsPanel.lua:23,
+    -- flipped by toggle() at :83), so it is read rather than called.
+    local panel = mgr.settingsPanel
+    local panelOpen = panel ~= nil and panel.isOpen == true
+
+    -- Event HUD only draws when no GUI/menu and no panel is open.
+    if not panelOpen and g_gui and not g_gui:getIsGuiVisible() then
         if mgr.eventHUD then mgr.eventHUD:draw() end
     end
 
-    -- Settings panel draws independently — it has its own isOpen guard and must
-    -- always render when open so hitboxes are rebuilt each frame.
-    if mgr.settingsPanel then mgr.settingsPanel:draw() end
+    -- The panel still draws every frame while open, unchanged: it rebuilds its
+    -- own hitboxes during draw, so skipping it would break its clicks.
+    if panel then panel:draw() end
 end
 
 -- Register with MasterHUD if present. Called from loadFinished

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.1.8.0</version>
+    <version>2.1.8.1</version>
     <modName>FS25_RandomWorldEvents</modName>
     <title>
         <en>Random World Events</en>


### PR DESCRIPTION
## The event HUD stands down while the settings panel is open

Reported in-game alongside the same symptom in SoilFertilizer: the event HUD's text reads straight **through** the RWE settings panel drawn over it.

### Cause

**A panel background is an OVERLAY, and an overlay does not cover text that was already rendered underneath it.** `drawStack` draws `eventHUD` first and `settingsPanel` second, so painting the panel on top was never going to hide the HUD. It has to not draw.

### The guard already existed with the wrong list

The event HUD already stood down for a GUI menu:

```lua
if g_gui and not g_gui:getIsGuiVisible() then
```

A drawn panel is not a `g_gui` surface, so that condition could not see one. This adds the panel to the **same** condition rather than inventing a new rule. Identical in shape to the fix landing in SoilFertilizer PR #834.

### Two details worth flagging for review

**`isOpen` is a FIELD here, not a method.** `RWESettingsPanel.lua:23` sets `self.isOpen = false` and `toggle()` at `:83` flips it, unlike SoilFertilizer's panel where `isOpen()` is a function. So it is read, not called. Getting this wrong would have made the guard permanently truthy, since a function value is always truthy, and the HUD would have vanished forever.

**The panel still draws every frame while open, unchanged.** It rebuilds its own hitboxes during `draw`, so skipping it the way SoilFertilizer skips its page content would break every click in the panel. Only the HUD stands down.

### Where

`RWEMasterHUDBridge.drawStack`, which both `RandomWorldEvents.lua:1144` (the standalone `FSBaseMission.draw` hook) and the MasterHUD registration at `:80` call. The file header says those two must never diverge, so the shared body is the only correct place.

### Verification

Lua 5.1 syntax clean via the pre-commit gate. **This repo has no Lua bench harness**, so unlike the SoilFertilizer fix there are no assertions behind this one; it is a single condition on a single line of state.

**Not verified in-game.** The pass is: trigger an event so the HUD is up, open the settings panel, and confirm no HUD text reads through it, then confirm the panel's tabs and toggles still respond.

### Not covered

The cross-mod half of the same report. IncomeMod, TaxMod and RWE HUDs also read through **SoilFertilizer's** panel, because MasterHUD's own suspend at `MasterHUD.lua:277` only covers `g_gui` surfaces (its comment says it was copied from SoilFertilizer, which is where the blind spot came from). That needs a suspend declaration on MasterHUD's subscribe contract and is a separate decision, not folded in here.
