### PR TITLE
feat(hud): declare the fullscreen claim to MasterHUD

### DIFF
--- a/integrations/RWEMasterHUDBridge.lua
+++ b/integrations/RWEMasterHUDBridge.lua
@@ -31,6 +31,29 @@ RWEMasterHUDBridge = {}
 RWEMasterHUDBridge.HUD_ID = "RandomWorldEvents_HUD"
 RWEMasterHUDBridge.active = false   -- MasterHUD present and we registered
 
+--- Does RWE currently own the whole screen?
+---
+--- Passed to MasterHUD as the subscribe spec's isFullscreen so that while our
+--- settings panel is open, EVERY other companion's HUD stands down too. Without
+--- it, their text renders before our panel and reads straight through it,
+--- because an overlay does not cover text already drawn underneath.
+---
+--- This is the cross-mod half only, and it has an effect only when MasterHUD is
+--- present, since MasterHUD owns cross-mod ordering. RWE's own event HUD is
+--- handled inside drawStack.
+---
+--- isOpen is a FIELD on this panel, not a method (RWESettingsPanel.lua:23,
+--- flipped by toggle() at :83), so it is read rather than called.
+---
+--- Called every frame from MasterHUD's draw loop, so it stays a plain read.
+---@return boolean
+function RWEMasterHUDBridge.isFullscreen()
+    local mgr = g_RandomWorldEvents
+    if mgr == nil then return false end
+    local panel = mgr.settingsPanel
+    return panel ~= nil and panel.isOpen == true
+end
+
 -- The full RWE HUD draw body. Byte-for-byte the same as the standalone
 -- FSBaseMission.draw hook. Resolves the manager from the canonical global so it
 -- can be driven either by MasterHUD's loop or by RWE's own hook.
@@ -65,6 +88,10 @@ function RWEMasterHUDBridge.register(mgr)
     local ok, err = pcall(function()
         hud:subscribe(RWEMasterHUDBridge.HUD_ID, {
             draw = RWEMasterHUDBridge.drawStack,
+            -- Stand every OTHER companion's HUD down while our panel owns the
+            -- screen. Optional on MasterHUD's side, so an older MasterHUD ignores
+            -- it and behaves exactly as before.
+            isFullscreen = RWEMasterHUDBridge.isFullscreen,
         })
     end)
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.1.8.0</version>
+    <version>2.1.8.2</version>
     <modName>FS25_RandomWorldEvents</modName>
     <title>
         <en>Random World Events</en>


### PR DESCRIPTION
## Declare the fullscreen claim to MasterHUD

Companion half of the `isFullscreen` contract wired in FS25_MasterHUD PR #7. **Merge that one first**; this is inert without it, and harmless.

### What it does

While RWE's settings panel is open, MasterHUD now stands **every other companion's HUD** down. Without it their text renders before our panel and reads straight through it, because **an overlay does not cover text already drawn underneath**.

### What it is not

**RWE's own event HUD is not this.** That is the single-mod half, handled inside `drawStack` by PR #34. This PR is only the cross-mod half.

**It only has an effect when MasterHUD is present**, since MasterHUD owns cross-mod ordering. Standalone, each mod draws its own stack and cannot see the others.

### The detail worth reviewing

**`isOpen` is a FIELD on `RWESettingsPanel`, not a method.** `:23` sets `self.isOpen = false`, `toggle()` at `:83` flips it, unlike the SoilFertilizer panels where `isOpen()` is a function. So it is read, not called. Calling it would have been wrong in the worst way: a function value is truthy on every frame, so the claim would never release and **every other mod's HUD would stay hidden permanently**.

### Compatibility

`isFullscreen` is optional on MasterHUD's side, so an older MasterHUD ignores the field and behaves exactly as before. **No version dependency**, and the PRs can land in either order.

### Verification

Lua 5.1 syntax clean via the pre-commit gate. **This repo has no Lua bench harness**, so there are no assertions behind this; it is one field read. **Not verified in-game**: needs MasterHUD PR #7 merged, then open RWE's settings panel with other companion HUDs on screen and confirm nothing reads through it.
