### PR TITLE
fix: stop Random World Events cab log flood and skip live action re-register

### DIFF
--- a/RandomWorldEvents.lua
+++ b/RandomWorldEvents.lua
@@ -1197,6 +1197,18 @@ installInputHooks = function()
             if _rweVehicleHookActive then return end
             if not g_RandomWorldEvents then return end
 
+            -- BUILD 17:45: the engine calls this constantly while the player is in a
+            -- cab. When all three vehicle slots are already live there is nothing to repair,
+            -- so the remove and re-register is skipped outright. A partial set still takes
+            -- the full path, because that is the case the teardown exists for. The return is
+            -- deliberately BEFORE the re-entrancy flag is set, so the skip cannot wedge the
+            -- hook shut.
+            if g_RandomWorldEvents.hudVehicleEventId ~= nil
+                and g_RandomWorldEvents.settingsVehicleEventId ~= nil
+                and g_RandomWorldEvents.hudDragVehicleEventId ~= nil then
+                return
+            end
+
             _rweVehicleHookActive = true
 
             -- Only remove vehicle-context IDs. Player-context IDs were registered
@@ -1224,7 +1236,6 @@ installInputHooks = function()
             if vHudOk and vHudId then
                 mgr.hudVehicleEventId = vHudId
                 binding:setActionEventText(vHudId, g_i18n:getText("input_RWE_TOGGLE_HUD") or "Toggle RWE HUD")
-                Logging.info("[RWE] HUD toggle registered in VEHICLE context")
             end
 
             local vSpOk, vSpId = binding:registerActionEvent(
@@ -1235,7 +1246,6 @@ installInputHooks = function()
             if vSpOk and vSpId then
                 mgr.settingsVehicleEventId = vSpId
                 binding:setActionEventTextVisibility(vSpId, false)
-                Logging.info("[RWE] Settings toggle registered in VEHICLE context")
             end
 
             local vDragOk, vDragId = binding:registerActionEvent(
@@ -1246,7 +1256,6 @@ installInputHooks = function()
             if vDragOk and vDragId then
                 mgr.hudDragVehicleEventId = vDragId
                 binding:setActionEventTextVisibility(vDragId, false)
-                Logging.info("[RWE] HUD drag registered in VEHICLE context")
             end
 
             binding:endActionEventsModification()

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.2.0.0</version>
+    <version>2.2.0.1</version>
     <modName>FS25_RandomWorldEvents</modName>
     <title>
         <en>Random World Events</en>


### PR DESCRIPTION
## Summary
- If all three vehicle action ids are live, return before re-register and before the re-entrancy flag.
- Drop per-call `registered in VEHICLE context` info logs. Version 2.2.0.1.

## Test plan
- [ ] Sit in a cab: no repeating `registered in VEHICLE context` lines
- [ ] RWE HUD / settings / drag keys still work in cab and on foot