### PR TITLE
Release v2.2.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ VEHICLE_PHYSICS_FINDINGS.txt
 
 # Built mod zip - never committed; ships only as a GitHub release asset
 FS25_RandomWorldEvents.zip
+
+# Pre-commit gate deps (tools/test/ - installed by npm, never shipped)
+node_modules/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,34 @@
 # FS25_RandomWorldEvents - Claude Code Project Instructions
 
+## Git Workflow — ONE FEATURE, ONE PR
+
+> **Tyson's ruling, 2026-08-10. BINDING on every human and every agent seat, including Bob, Fred and Sasha, because those seats are the ones opening PRs.**
+
+- **Every feature, fix or brief gets its OWN BRANCH**, cut fresh from `development`:
+  `feat/<ID>-<slug>`, `fix/<ID>-<slug>`, or `docs/<slug>` / `chore/<slug>` for non-code work
+  (e.g. `feat/SCS-037-caught-up-hour`).
+  Commit **only that one item** on it.
+- **The PR is `feat/...` → `development`.** One item per PR, always. Delete the branch on merge.
+- **NEVER open a feature PR from `development` itself.** `development` is the trunk: a PR based on it
+  silently absorbs every commit that lands while it is open, under a title that still describes the
+  first one. **This happened twice in two days**, the second time to the seat that had just reported it.
+- **`development` → `main` is a RELEASE PR only**, titled `Release vX.Y.Z`. It may carry many features
+  *by design* and its body lists them. It is never a feature PR.
+- **Never commit or push directly to `main`.** Check your branch at the start of every session.
+- If a PR does end up carrying more than its title says: **retitle, rebody with the full commit list,
+  and refresh every approval.** An old approval never covers code it did not see.
+
+```bash
+git checkout development && git pull
+git checkout -b feat/SCS-037-caught-up-hour
+#   ...commit the ONE feature...
+git push -u origin feat/SCS-037-caught-up-hour
+gh pr create --base development
+#   -> Sasha approves -> Tyson merges -> branch deleted
+```
+
+**Sasha approves, Tyson merges.** No seat both approves and lands the same PR.
+
 ## !! MANDATORY: Before Writing ANY FS25 API Code !!
 Before implementing any FS25 Lua API call, class usage, or game system interaction,
 ALWAYS check the following local reference folders first. These contain CORRECT,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,6 +15,12 @@
 - Baseline date: 2026-06-30 (updated 2026-07-25)
 
 ## Near-term (next release cycle)
+- [x] Redesign NON-PRICE HALF (2026-08-14, branch `feat/RWE-redesign-nonprice`, v2.2.0.0): keep the role, delegate the mechanism.
+  - CUT 13 arcade edges entirely: time_acceleration, time_slowdown, bonus_xp, malus_xp, money_bonus, money_malus, vehicle_fuel_bonus, vehicle_fuel_penalty, vehicle_free_upgrade, vehicle_cleaning_bonus, vehicle_steering_pull, vehicle_slippery_roads, fuel_discount. No more timeScale writes, no more repPoints writes, no more cash-from-nowhere trickles for the field/animal/special read-signals (the field and animal per-60-second money tick handlers are removed; the harvest festival's money trickle stays until the gated money half lands).
+  - World/sim events (crop_yield, fertilizer, seed_growth, animal_product, wolf_sighting, bumper_wool_season, disease_scare, wildlife_pest_invasion) are now PULL read-signals: RWE announces and exposes them; SoilFertilizer / CropDisease / DairyCore apply their own model. The read surface is complete on the manager: getActiveEvent, isEventActive, getProgress, getRemainingTime, getIntensity (nil when nothing active), getEventIntensity (numeric).
+  - Arcade physics moved behind the opt-in `RandomWorldEvents.arcadePhysics` toggle (default OFF, admin SettingsHub key): vehicle_speed_boost, vehicle_engine_trouble, equipment_durability_boost/drop only enter the trigger pool when ON, and the `Vehicle.addDamageAmount` patch only scales the player's own vehicle when ON. The 4 events keep the current player-vehicle scoping.
+  - Difficulty rides the Option-Scaling Spine: vendored the pure `OptionScalingResolver` (byte-identical to SettingsHub's spine branch); `getDifficulty()` reads the World-events dial (frequency + base intensity, applied to the scheduler) and the Economy dial (exposed for the gated economic half). Spine absent or dial off = neutral = RWE's own settings.
+  - Event catalog 53 -> 40 (economic 14, field 10, vehicle 4, wildlife 8, special 4). Help text and category counts updated in 26 languages; new arcadePhysics strings in 26 languages.
 - [x] Release gate mechanism (2026-08-04): wired per Arissani's 2026-08-03 lock set (EMPTY for RWE - the redesign is unbuilt; only bug fixes have shipped, and fixes flow free). `ReleaseGate.lua` with an empty registry, `experimentalSystems` opt-in (default false, orthogonal to difficulty) through settings/persistence/SettingsHub/panel, and the `rweRelease` status command. Nothing gated today.
 - [x] MP money bug (F16): DONE in v2.1.7.1. Money routes through `rweAddMoney`, gated on `getIsServer` (confirmed by the 2026-07-09 money-authority sweep).
 - [x] Server-gate the special-event reputation write (7b076c4) and remove the last `Logging.debug` nil-call crash in the vehicle input hook (#20, a49fcbc). DONE.
@@ -35,5 +41,13 @@
 - [ ] Read by MarketDynamics (`getPriceModifier` via the economic subsystem).
 - [x] Bedrock migrations DONE: StateLedger + SettingsHub + MasterHUD bridged (NetworkSync N/A by design).
 
+## Gated follow-up (blocked by design, do not build ahead)
+The NON-PRICE HALF of the redesign is built (2026-08-14); these halves stay on the shelf:
+- [ ] PRICE half (blocked on the MarketDynamics re-home): market_boom/crash, price_fixing, export_opportunity, harvest/field_sale, bonus_trade_prices and the economic_crisis market-malus move from the EffectHooks getPricePerLiter patch to registered MarketDynamics price modifiers. The patch stays in place until then; only the read-signal flags (yieldBonus/yieldMalus) have left it.
+- [ ] MONEY half (blocked on the onDayChange settlement): government_subsidy, sudden_expense, farmer_donation, insurance_bonus, tax_refund, loan_interest, economic_crisis loan cost, feed_shortage, veterinary_windfall, vehicle_accident, vehicle_repair_bill and the shop discounts accrue and settle on onDayChange via TaxMod recordExpense instead of instant addMoney. The instant server-gated addMoney calls are preserved until then.
+- [ ] Economy-dial application: the spine's Economy dial is read and exposed via getDifficulty() but not yet applied to economic magnitudes; it lands with the money/price re-homes.
+- [ ] NOTE: the workspace notes record MarketDynamics registerPriceModifier as already built (1.2.0.9) as of 2026-07-31, which contradicts the brief's gate note. The price half stays unbuilt per the brief regardless; re-verify the dependency before building it.
+
 ## Deferred / parked
 - Event scheduling / prediction API: parked by design. Events are probabilistic; peers read active state and cooldown only.
+- Stale help copy outside the redesign's cut list (pre-existing fiction in helpLine_rwe_cat3_wildlife and similar) is fixed where it named cut features; the remainder is a docs sweep, not a code issue.

--- a/RandomWorldEvents.lua
+++ b/RandomWorldEvents.lua
@@ -37,6 +37,11 @@ RandomWorldEvents = {
         showHUD = true,
         cooldown = 30,
 
+        -- Arcade-physics opt-in (default OFF). When ON, the retained physics
+        -- events (speed boost, engine trouble, equipment durability) may fire,
+        -- scoped to the player's own vehicle and out of the economy.
+        arcadePhysics = false,
+
         weatherEvents = false,
         economicEvents = true,
         vehicleEvents = true,
@@ -145,6 +150,7 @@ function RandomWorldEvents:createSettingsManager()
                 showWarnings = true,
                 showHUD = true,
                 cooldown = 30,
+                arcadePhysics = false,
                 weatherEvents = false,
                 economicEvents = true,
                 vehicleEvents = true,
@@ -193,6 +199,7 @@ function RandomWorldEvents:createSettingsManager()
                 settingsObject.events.showWarnings = xml:getBool(manager.XMLTAG..".events.showWarnings", manager.defaultConfig.events.showWarnings)
                 settingsObject.events.showHUD = xml:getBool(manager.XMLTAG..".events.showHUD", manager.defaultConfig.events.showHUD)
                 settingsObject.events.cooldown = xml:getInt(manager.XMLTAG..".events.cooldown", manager.defaultConfig.events.cooldown)
+                settingsObject.events.arcadePhysics = xml:getBool(manager.XMLTAG..".events.arcadePhysics", manager.defaultConfig.events.arcadePhysics)
                 settingsObject.hudScale = xml:getFloat(manager.XMLTAG..".hudScale", manager.defaultConfig.hudScale)
                 settingsObject.events.weatherEvents = xml:getBool(manager.XMLTAG..".events.weatherEvents", manager.defaultConfig.events.weatherEvents)
                 settingsObject.events.economicEvents = xml:getBool(manager.XMLTAG..".events.economicEvents", manager.defaultConfig.events.economicEvents)
@@ -264,6 +271,7 @@ function RandomWorldEvents:createSettingsManager()
             xml:setBool(manager.XMLTAG..".events.showWarnings", settingsObject.events.showWarnings)
             xml:setBool(manager.XMLTAG..".events.showHUD", settingsObject.events.showHUD)
             xml:setInt(manager.XMLTAG..".events.cooldown", settingsObject.events.cooldown)
+            xml:setBool(manager.XMLTAG..".events.arcadePhysics", settingsObject.events.arcadePhysics == true)
             xml:setFloat(manager.XMLTAG..".hudScale", settingsObject.hudScale or 1.0)
             xml:setBool(manager.XMLTAG..".events.weatherEvents", settingsObject.events.weatherEvents)
             xml:setBool(manager.XMLTAG..".events.economicEvents", settingsObject.events.economicEvents)
@@ -352,6 +360,67 @@ function RandomWorldEvents:allowsExperimentalSystems()
     return self.experimentalSystems == true
 end
 
+--- Arcade-physics opt-in (redesign): the retained vehicle-physics events
+--- (speed boost, engine trouble, equipment durability) only fire when this is
+--- ON. Default OFF. Always scoped to the player's own vehicle, never an NPC
+--- machine, never the economy. Admin key RandomWorldEvents.arcadePhysics.
+---@return boolean
+function RandomWorldEvents:allowsArcadePhysics()
+    return self.events.arcadePhysics == true
+end
+
+-- =====================
+-- DIFFICULTY (Option-Scaling Spine)
+-- Difficulty rides the spine: the World-events dial scales event frequency
+-- and base intensity; the Economy dial scales economic magnitude. When the
+-- spine (or its profile) is absent every read is neutral, meaning RWE falls
+-- back to its own configured frequency/intensity untouched.
+-- =====================
+
+--- Read the Option-Scaling Spine profile (if present) and resolve the two dials
+--- RWE rides on. Neutral (nil) when the spine is absent or its profile is not
+--- registered. Each factor is a multiplier around 1.0 (0.4 relaxed .. 1.7
+--- punishing on the canonical World-events curve).
+---@return table|nil  { worldEvents = number, economy = number }
+function RandomWorldEvents:getDifficulty()
+    if OptionScalingResolver == nil or OptionScalingResolver.readProfile == nil then
+        return nil
+    end
+    local hub = (g_currentMission ~= nil and g_currentMission.settingsHub) or g_settingsHub
+    local profile = OptionScalingResolver.readProfile(hub)
+    if profile == nil then return nil end
+    return {
+        worldEvents = OptionScalingResolver.resolve({ dial = "worldEvents", base = 1.0, neutral = 1.0 }, profile),
+        economy     = OptionScalingResolver.resolve({ dial = "economy",     base = 1.0, neutral = 1.0 }, profile),
+    }
+end
+
+--- Difficulty factor for one dial (1.0 = neutral, spine absent or dial off).
+---@param dial string  "worldEvents" or "economy"
+---@return number
+function RandomWorldEvents:getDifficultyFactor(dial)
+    local d = self:getDifficulty()
+    if d == nil or d[dial] == nil then return 1.0 end
+    return d[dial]
+end
+
+--- Spine-scaled event frequency (1-10). Neutral when the spine is absent.
+---@return number
+function RandomWorldEvents:getEffectiveFrequency()
+    local f = tonumber(self.events.frequency) or 5
+    local scaled = f * self:getDifficultyFactor("worldEvents")
+    return math.max(1, math.min(10, math.floor(scaled)))
+end
+
+--- Spine-scaled base intensity (1-5) used to trigger and scale events.
+--- Neutral when the spine is absent.
+---@return number
+function RandomWorldEvents:getBaseIntensity()
+    local i = tonumber(self.events.intensity) or 2
+    local scaled = i * self:getDifficultyFactor("worldEvents")
+    return math.max(1, math.min(5, math.floor(scaled)))
+end
+
 function RandomWorldEvents:consoleCommandRelease()
     if not ReleaseGate then return "Release gate not loaded" end
     return ReleaseGate.status(self.experimentalSystems == true)
@@ -396,6 +465,44 @@ end
 function RandomWorldEvents:getEventIntensity()
     local es = self.EVENT_STATE
     if es == nil or es.activeEvent == nil then return 0 end
+    return es.activeIntensity or self.events.intensity or 1
+end
+
+--- True while a world event is active.
+---@return boolean
+function RandomWorldEvents:isEventActive()
+    local es = self.EVENT_STATE
+    return es ~= nil and es.activeEvent ~= nil
+end
+
+--- Progress through the active event (0.0 -> 1.0), or 0 when none is active.
+---@return number
+function RandomWorldEvents:getProgress()
+    if not self:isEventActive() then return 0 end
+    local s = self.EVENT_STATE
+    if s.eventDuration == nil or s.eventDuration <= 0 then return 1 end
+    local elapsed = (g_currentMission and g_currentMission.time or 0) - (s.eventStartTime or 0)
+    return math.max(0, math.min(1, elapsed / s.eventDuration))
+end
+
+--- Seconds remaining in the active event, or 0 when none is active.
+---@return number
+function RandomWorldEvents:getRemainingTime()
+    if not self:isEventActive() then return 0 end
+    local s = self.EVENT_STATE
+    if s.eventDuration == nil then return 0 end
+    local now = g_currentMission and g_currentMission.time or 0
+    local remainingMs = math.max(0, (s.eventStartTime or 0) + s.eventDuration - now)
+    return math.floor(remainingMs / 1000)
+end
+
+--- Intensity (1-5) of the currently active event, or nil when none is active.
+--- Neutral is nil (nothing active), matching the redesign read contract; use
+--- getEventIntensity() if a numeric 0-when-inactive is preferred.
+---@return number|nil
+function RandomWorldEvents:getIntensity()
+    local es = self.EVENT_STATE
+    if es == nil or es.activeEvent == nil then return nil end
     return es.activeIntensity or self.events.intensity or 1
 end
 
@@ -452,14 +559,22 @@ function RandomWorldEvents:triggerRandomEvent()
         return false
     end
     
+    local baseIntensity = self:getBaseIntensity()
     local available = {}
     for eventId, event in pairs(self.EVENTS) do
         local categoryKey = event.category .. "Events"
         local categoryEnabled = self.events[categoryKey]
         local canTrigger = event.canTrigger()
-        local intensityOk = self.events.intensity >= (event.minIntensity or 1)
-        
-        if categoryEnabled and canTrigger and intensityOk then
+        local intensityOk = baseIntensity >= (event.minIntensity or 1)
+
+        -- Opt-in gate for the retained arcade-physics events (redesign):
+        -- they only enter the pool when the arcadePhysics toggle is ON.
+        local gateOk = true
+        if event.gate == "arcadePhysics" then
+            gateOk = self:allowsArcadePhysics()
+        end
+
+        if categoryEnabled and canTrigger and intensityOk and gateOk then
             table.insert(available, eventId)
         end
     end
@@ -486,7 +601,7 @@ function RandomWorldEvents:triggerRandomEvent()
         end
     end
     local event = self.EVENTS[eventId]
-    self:_activateEvent(event, self.events.intensity)
+    self:_activateEvent(event, self:getBaseIntensity())
     return true
 end
 
@@ -613,7 +728,7 @@ function RandomWorldEvents:update(dt)
     if self.events.enabled then
         if g_server == nil then return end
         if g_currentMission.time > (self.EVENT_STATE.cooldownUntil or 0) then
-            local chance = self.events.frequency * 0.001
+            local chance = self:getEffectiveFrequency() * 0.001
             local roll = math.random()
             if roll <= chance then
                 self:dbg(string.format("roll %.4f <= chance %.4f — attempting trigger", roll, chance), 2)
@@ -694,7 +809,10 @@ function RandomWorldEvents:_tickImmersion()
     if not s.midpointFired and duration > 0 and elapsed >= duration * 0.50 then
         s.midpointFired = true
         if event.onMid then
-            local ok, msg = pcall(event.onMid, self.events.intensity)
+            -- Midpoint narrative must mirror the intensity the event was
+            -- actually activated at (spine-scaled), not the raw setting.
+            local midIntensity = s.activeIntensity or self:getBaseIntensity()
+            local ok, msg = pcall(event.onMid, midIntensity)
             if ok and msg then
                 self:notifyEvent(msg, event.category, "warn")
                 self:dbg("Midpoint fired for: " .. s.activeEvent)
@@ -744,17 +862,21 @@ function RandomWorldEvents:consoleCommandStatus()
     local status = string.format(
         "=== RWE Status ===\n" ..
         "Events enabled: %s\n" ..
-        "Frequency: %d/10\n" ..
-        "Intensity: %d/5\n" ..
+        "Frequency: %d/10 (spine %d)\n" ..
+        "Intensity: %d/5 (spine %d)\n" ..
         "Active event: %s\n" ..
         "Cooldown active: %s\n" ..
+        "Arcade physics: %s\n" ..
         "Physics enabled: %s\n" ..
         "=========================",
         tostring(self.events.enabled),
-        self.events.frequency,
-        self.events.intensity,
+        self.events.frequency or 5,
+        self:getEffectiveFrequency(),
+        self.events.intensity or 2,
+        self:getBaseIntensity(),
         self.EVENT_STATE.activeEvent or "None",
         tostring(g_currentMission.time < self.EVENT_STATE.cooldownUntil),
+        tostring(self:allowsArcadePhysics()),
         tostring(self.physics.enabled)
     )
     print(status)

--- a/RandomWorldEvents.lua
+++ b/RandomWorldEvents.lua
@@ -1197,6 +1197,18 @@ installInputHooks = function()
             if _rweVehicleHookActive then return end
             if not g_RandomWorldEvents then return end
 
+            -- BUILD 17:45: the engine calls this constantly while the player is in a
+            -- cab. When all three vehicle slots are already live there is nothing to repair,
+            -- so the remove and re-register is skipped outright. A partial set still takes
+            -- the full path, because that is the case the teardown exists for. The return is
+            -- deliberately BEFORE the re-entrancy flag is set, so the skip cannot wedge the
+            -- hook shut.
+            if g_RandomWorldEvents.hudVehicleEventId ~= nil
+                and g_RandomWorldEvents.settingsVehicleEventId ~= nil
+                and g_RandomWorldEvents.hudDragVehicleEventId ~= nil then
+                return
+            end
+
             _rweVehicleHookActive = true
 
             -- Only remove vehicle-context IDs. Player-context IDs were registered
@@ -1224,7 +1236,6 @@ installInputHooks = function()
             if vHudOk and vHudId then
                 mgr.hudVehicleEventId = vHudId
                 binding:setActionEventText(vHudId, g_i18n:getText("input_RWE_TOGGLE_HUD") or "Toggle RWE HUD")
-                Logging.info("[RWE] HUD toggle registered in VEHICLE context")
             end
 
             local vSpOk, vSpId = binding:registerActionEvent(
@@ -1235,7 +1246,6 @@ installInputHooks = function()
             if vSpOk and vSpId then
                 mgr.settingsVehicleEventId = vSpId
                 binding:setActionEventTextVisibility(vSpId, false)
-                Logging.info("[RWE] Settings toggle registered in VEHICLE context")
             end
 
             local vDragOk, vDragId = binding:registerActionEvent(
@@ -1246,7 +1256,6 @@ installInputHooks = function()
             if vDragOk and vDragId then
                 mgr.hudDragVehicleEventId = vDragId
                 binding:setActionEventTextVisibility(vDragId, false)
-                Logging.info("[RWE] HUD drag registered in VEHICLE context")
             end
 
             binding:endActionEventsModification()

--- a/TODO.md
+++ b/TODO.md
@@ -17,6 +17,7 @@
 - [x] RWE-001 / RWE-002 / RWE-003 / RWE-004: additional RandomWorldEvents bugs fixed in 2026-07-26 bug sweep, merged to main.
 
 ## Features / enhancements
+- [x] Redesign NON-PRICE HALF (2026-08-14, branch `feat/RWE-redesign-nonprice`, v2.2.0.0). CUT 13 arcade edges (time warps, rep, cash-from-nowhere, magic fuel, free upgrades/cleaning, steering pull, slippery roads, fuel discount); world/sim events are now PULL read-signals; arcade physics behind the opt-in `arcadePhysics` toggle (default OFF, player-vehicle only, never economy); difficulty rides the Option-Scaling Spine (vendored resolver, World-events dial applied to frequency + base intensity, Economy dial exposed); read surface completed (getActiveEvent / isEventActive / getProgress / getRemainingTime / getIntensity / getIntensity-nil). Event catalog 53 -> 40. Bench at `tools/test/rwe-redesign-bench.mjs` (16 checks).
 - [x] Release gate mechanism (2026-08-04): `ReleaseGate.lua` with an EMPTY registry (Arissani 2026-08-03). `experimentalSystems` opt-in (default false, orthogonal to difficulty) through the settings manager load/save, the SettingsHub mirror and a settings-panel toggle. `rweRelease` status command. Nothing gated; a row drops in the moment a system needs locking.
 - [x] Bedrock migration DONE: StateLedger + SettingsHub + MasterHUD bridged (NetworkSync N/A by design).
 
@@ -32,4 +33,7 @@
 - [ ] Update README/version on each release.
 
 ## Blocked / waiting on
-- [!] Vehicle-event server-gate exemption decision (waits on: audit answer, whether physics events skip the getIsServer gate since they are local-player physics, not farm balance).
+- [!] Redesign PRICE half (gated): re-home the retained price events to MarketDynamics registered price modifiers; the EffectHooks getPricePerLiter patch stays until then. Brief gate says registerPriceModifier is unbuilt; notes.md records it as built (1.2.0.9, MarketDynamics.lua:301) since 2026-07-31 - re-verify at build time, do not build ahead.
+- [!] Redesign MONEY half (gated): accrue retained money events and settle on onDayChange via TaxMod recordExpense (both directions); instant server-gated addMoney stays until then. Includes the harvest-festival money trickle.
+- [!] Economy-dial application: read + exposed via getDifficulty(), application lands with the money/price re-homes.
+- [!] Vehicle-event server-gate exemption decision (waits on: audit answer, whether physics events skip the getIsServer gate since they are local-player physics, not farm balance). Superseded in practice by the arcadePhysics opt-in + player-vehicle scoping.

--- a/gui/RWEEventHUD.lua
+++ b/gui/RWEEventHUD.lua
@@ -587,9 +587,11 @@ function RWEEventHUD:drawPanel()
         cy = cy - lh
     end
 
-    -- Stats row: frequency / intensity
-    local freq = rwe.events.frequency or 5
-    local inten = rwe.events.intensity or 2
+    -- Stats row: frequency / intensity (effective values, spine-scaled when
+    -- the Option-Scaling Spine is present so the HUD never disagrees with the
+    -- actual trigger logic).
+    local freq = rwe.getEffectiveFrequency ~= nil and rwe:getEffectiveFrequency() or (rwe.events.frequency or 5)
+    local inten = rwe.getBaseIntensity ~= nil and rwe:getBaseIntensity() or (rwe.events.intensity or 2)
     setTextAlignment(RenderText.ALIGN_LEFT)
     setTextColor(self.COLORS.DIM[1], self.COLORS.DIM[2], self.COLORS.DIM[3], 1)
     renderText(x, cy - tsSmall, tsSmall,

--- a/gui/RWESettingsIntegration.lua
+++ b/gui/RWESettingsIntegration.lua
@@ -102,6 +102,12 @@ function RWESettingsIntegration:addSettingsElements(frame)
         g_i18n:getText("rwe_cooldown_long")  or "Minimum in-game time between events"
     )
 
+    frame.rwe_arcadePhysics = RWESettingsIntegration:addBinaryOption(
+        frame, "onRWEArcadePhysicsChanged",
+        g_i18n:getText("rwe_arcade_physics_short") or "Arcade Physics",
+        g_i18n:getText("rwe_arcade_physics_long")  or "Allow arcade vehicle-physics events (player vehicle only, default off)"
+    )
+
     -- ── Notifications & HUD ───────────────────────────────
     RWESettingsIntegration:addSubHeader(frame,
         g_i18n:getText("rwe_subheader_hud") or "Notifications & HUD"
@@ -367,6 +373,11 @@ function RWESettingsIntegration:updateSettingsUI(frame)
             RWESettingsIntegration.hudScaleValues, scale))
     end
 
+    -- Arcade physics opt-in
+    if frame.rwe_arcadePhysics then
+        frame.rwe_arcadePhysics:setIsChecked(ev.arcadePhysics == true, false, false)
+    end
+
     -- Categories
     if frame.rwe_economicEvents then
         frame.rwe_economicEvents:setIsChecked(ev.economicEvents == true, false, false)
@@ -446,6 +457,10 @@ end
 
 function RWESettingsIntegration:onRWECooldownChanged(state)
     applyEventSetting("cooldown", RWESettingsIntegration.cooldownValues[state] or 30)
+end
+
+function RWESettingsIntegration:onRWEArcadePhysicsChanged(state)
+    applyEventSetting("arcadePhysics", state == BinaryOptionElement.STATE_RIGHT)
 end
 
 function RWESettingsIntegration:onRWENotificationsChanged(state)

--- a/gui/RWESettingsPanel.lua
+++ b/gui/RWESettingsPanel.lua
@@ -233,6 +233,7 @@ function RWESettingsPanel:drawEventsTab(x, y, w)
     cy = self:drawHeader(x, cy, w, "GLOBAL SETTINGS")
     cy = self:drawToggle(x, cy, w, "Enable All Events", ev.enabled, function(v) ev.enabled = v end)
     cy = self:drawToggle(x, cy, w, "Experimental Systems", self.rwe.experimentalSystems, function(v) self.rwe.experimentalSystems = v end)
+    cy = self:drawToggle(x, cy, w, "Arcade Physics", ev.arcadePhysics, function(v) ev.arcadePhysics = v end)
     cy = cy - 0.01
     
     cy = self:drawHeader(x, cy, w, "TIMING & CHANCE")

--- a/integrations/RWEMasterHUDBridge.lua
+++ b/integrations/RWEMasterHUDBridge.lua
@@ -41,14 +41,27 @@ function RWEMasterHUDBridge.drawStack()
     local mgr = g_RandomWorldEvents
     if mgr == nil then return end
 
-    -- Event HUD only draws when no GUI/menu is open.
-    if g_gui and not g_gui:getIsGuiVisible() then
+    -- THE SETTINGS PANEL OWNS THE SCREEN WHILE IT IS OPEN, so the event HUD
+    -- stands down for it exactly as it already stands down for a GUI menu.
+    --
+    -- A panel background is an OVERLAY, and an overlay does not cover text that
+    -- was already rendered underneath it. The event HUD draws first, so its text
+    -- read straight THROUGH the panel. A HUD cannot be hidden by drawing the
+    -- panel on top of it; it has to not draw.
+    --
+    -- isOpen is a FIELD on this panel, not a method (RWESettingsPanel.lua:23,
+    -- flipped by toggle() at :83), so it is read rather than called.
+    local panel = mgr.settingsPanel
+    local panelOpen = panel ~= nil and panel.isOpen == true
+
+    -- Event HUD only draws when no GUI/menu and no panel is open.
+    if not panelOpen and g_gui and not g_gui:getIsGuiVisible() then
         if mgr.eventHUD then mgr.eventHUD:draw() end
     end
 
-    -- Settings panel draws independently — it has its own isOpen guard and must
-    -- always render when open so hitboxes are rebuilt each frame.
-    if mgr.settingsPanel then mgr.settingsPanel:draw() end
+    -- The panel still draws every frame while open, unchanged: it rebuilds its
+    -- own hitboxes during draw, so skipping it would break its clicks.
+    if panel then panel:draw() end
 end
 
 -- Register with MasterHUD if present. Called from loadFinished

--- a/integrations/RWEMasterHUDBridge.lua
+++ b/integrations/RWEMasterHUDBridge.lua
@@ -35,6 +35,9 @@ RWEMasterHUDBridge.active = false   -- MasterHUD present and we registered
 -- FSBaseMission.draw hook. Resolves the manager from the canonical global so it
 -- can be driven either by MasterHUD's loop or by RWE's own hook.
 function RWEMasterHUDBridge.drawStack()
+    -- Suite hide: MasterHUD # key. No-op when MasterHUD absent.
+    local mh = (g_currentMission ~= nil and g_currentMission.masterHUD) or g_masterHUD
+    if mh ~= nil and mh.areHudsHidden ~= nil and mh:areHudsHidden() then return end
     local mgr = g_RandomWorldEvents
     if mgr == nil then return end
 
@@ -68,6 +71,21 @@ function RWEMasterHUDBridge.register(mgr)
     if ok then
         RWEMasterHUDBridge.active = true
         Logging.info("[RWE] Registered RWE HUD with MasterHUD (single draw loop + menu-suspend)")
+        if hud.registerEditListener ~= nil then
+            hud:registerEditListener(RWEMasterHUDBridge.HUD_ID, {
+                enter = function()
+                    if mgr ~= nil and mgr.eventHUD ~= nil and mgr.eventHUD.enterEditMode ~= nil then
+                        mgr.eventHUD:enterEditMode()
+                    end
+                end,
+                exit = function()
+                    if mgr ~= nil and mgr.eventHUD ~= nil and mgr.eventHUD.editMode
+                        and mgr.eventHUD.exitEditMode ~= nil then
+                        mgr.eventHUD:exitEditMode()
+                    end
+                end,
+            })
+        end
     else
         Logging.warning("[RWE] MasterHUD registration failed: %s (using own draw hook)", tostring(err))
     end

--- a/integrations/RWEMasterHUDBridge.lua
+++ b/integrations/RWEMasterHUDBridge.lua
@@ -31,6 +31,29 @@ RWEMasterHUDBridge = {}
 RWEMasterHUDBridge.HUD_ID = "RandomWorldEvents_HUD"
 RWEMasterHUDBridge.active = false   -- MasterHUD present and we registered
 
+--- Does RWE currently own the whole screen?
+---
+--- Passed to MasterHUD as the subscribe spec's isFullscreen so that while our
+--- settings panel is open, EVERY other companion's HUD stands down too. Without
+--- it, their text renders before our panel and reads straight through it,
+--- because an overlay does not cover text already drawn underneath.
+---
+--- This is the cross-mod half only, and it has an effect only when MasterHUD is
+--- present, since MasterHUD owns cross-mod ordering. RWE's own event HUD is
+--- handled inside drawStack.
+---
+--- isOpen is a FIELD on this panel, not a method (RWESettingsPanel.lua:23,
+--- flipped by toggle() at :83), so it is read rather than called.
+---
+--- Called every frame from MasterHUD's draw loop, so it stays a plain read.
+---@return boolean
+function RWEMasterHUDBridge.isFullscreen()
+    local mgr = g_RandomWorldEvents
+    if mgr == nil then return false end
+    local panel = mgr.settingsPanel
+    return panel ~= nil and panel.isOpen == true
+end
+
 -- The full RWE HUD draw body. Byte-for-byte the same as the standalone
 -- FSBaseMission.draw hook. Resolves the manager from the canonical global so it
 -- can be driven either by MasterHUD's loop or by RWE's own hook.
@@ -65,6 +88,10 @@ function RWEMasterHUDBridge.register(mgr)
     local ok, err = pcall(function()
         hud:subscribe(RWEMasterHUDBridge.HUD_ID, {
             draw = RWEMasterHUDBridge.drawStack,
+            -- Stand every OTHER companion's HUD down while our panel owns the
+            -- screen. Optional on MasterHUD's side, so an older MasterHUD ignores
+            -- it and behaves exactly as before.
+            isFullscreen = RWEMasterHUDBridge.isFullscreen,
         })
     end)
 

--- a/integrations/RWESettingsHubBridge.lua
+++ b/integrations/RWESettingsHubBridge.lua
@@ -40,6 +40,7 @@ local SETTINGS = {
     { id = "frequency",           section = "events",  key = "frequency",           type = "int",   admin = true,  min = 1,   max = 10,  l10n = "rwe_frequency_short" },
     { id = "intensity",           section = "events",  key = "intensity",           type = "int",   admin = true,  min = 1,   max = 5,   l10n = "rwe_intensity_short" },
     { id = "cooldown",            section = "events",  key = "cooldown",            type = "int",   admin = true,  min = 5,   max = 240, l10n = "rwe_cooldown_short" },
+    { id = "arcadePhysics",       section = "events",  key = "arcadePhysics",       type = "bool",  admin = true,  l10n = "rwe_arcade_physics_short" },
     { id = "showNotifications",   section = "events",  key = "showNotifications",   type = "bool",  admin = false, l10n = "rwe_notifications_short" },
     { id = "showWarnings",        section = "events",  key = "showWarnings",        type = "bool",  admin = false, l10n = "rwe_warnings_short" },
     { id = "showHUD",             section = "events",  key = "showHUD",             type = "bool",  admin = false, l10n = "rwe_show_hud_short" },

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.2.0.0</version>
+    <version>2.2.0.1</version>
     <modName>FS25_RandomWorldEvents</modName>
     <title>
         <en>Random World Events</en>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.1.8.2</version>
+    <version>2.2.0.0</version>
     <modName>FS25_RandomWorldEvents</modName>
     <title>
         <en>Random World Events</en>
@@ -20,7 +20,7 @@
          adapted from "RealPhysics Steering" by Tubez47. Credit recorded in the source
          header of utils/VehiclePhysics.lua, README.md and DEVELOPMENT.md. -->
     <description>
-        <en>Adds random events, real vehicle-physics effects, and configurable settings. The vehicle "steering pull" effect uses a technique adapted from RealPhysics Steering by Tubez47 - thank you!</en>
+        <en>Adds realistic random world events and configurable settings. An opt-in arcade physics layer (player vehicle only) can add event-driven speed, engine and durability effects. The physics layer uses a technique adapted from RealPhysics Steering by Tubez47 - thank you!</en>
         <de>Fügt zufällige Ereignisse, Physik-Überarbeitung und konfigurierbare Einstellungen hinzu.</de>
         <fr>Ajoute des événements aléatoires, une refonte de la physique et des paramètres configurables.</fr>
         <pl>Dodaje losowe wydarzenia, przebudowę fizyki i konfigurowalne ustawienia.</pl>
@@ -61,6 +61,9 @@
         <sourceFile filename="gui/RWEEventHUD.lua"/>
         <sourceFile filename="gui/RWESettingsIntegration.lua"/>
         <sourceFile filename="utils/EffectHooks.lua"/>
+        <!-- Vendored Option-Scaling Spine resolver (pure library, byte-identical
+             to SettingsHub's spine branch). OFF/absent == neutral, see header. -->
+        <sourceFile filename="utils/OptionScalingResolver.lua"/>
         <!-- Vehicle physics controller (specialization) must load before the
              vehicle events that drive it, and installs its type hook on load. -->
         <sourceFile filename="utils/VehiclePhysics.lua"/>
@@ -440,11 +443,11 @@
             <ru>[EN] Vehicle Events</ru>
         </text>
         <text name="rwe_vehicle_long">
-            <en>Enable vehicle events (speed, fuel, damage)</en>
-            <uk>Увімкнути події з технікою (швидкість, паливо, пошкодження)</uk>
-            <da>Aktivér køretøjshændelser (hastighed, brændstof, skader)</da>
+            <en>Enable vehicle events (speed, engine, damage)</en>
+            <uk>Увімкнути події з технікою (швидкість, двигун, пошкодження)</uk>
+            <da>Aktivér køretøjshændelser (hastighed, motor, skader)</da>
         
-            <de>Aktiviere Fahrzeugereignisse (Geschwindigkeit, Verbrauch, Schaden)</de>
+            <de>Aktiviere Fahrzeugereignisse (Geschwindigkeit, Motor, Schaden)</de>
             <fr>[EN] Enable vehicle events (speed, fuel, damage)</fr>
             <pl>[EN] Enable vehicle events (speed, fuel, damage)</pl>
             <es>[EN] Enable vehicle events (speed, fuel, damage)</es>
@@ -524,11 +527,11 @@
             <ru>[EN] Special Events</ru>
         </text>
         <text name="rwe_special_long">
-            <en>Enable time, XP, and special events</en>
-            <uk>Увімкнути події з часом, досвідом та особливі події</uk>
-            <da>Aktivér tids-, XP- og Særlige hændelser</da>
+            <en>Enable special events (festivals, trade prices, durability)</en>
+            <uk>Увімкнути особливі події (фестивалі, торгові ціни, міцність)</uk>
+            <da>Aktivér særlige hændelser (festivaler, handelspriser, holdbarhed)</da>
         
-            <de>Zeit-, EP- und Spezialereignisse aktivieren</de>
+            <de>Spezialereignisse aktivieren (Feste, Handelspreise, Haltbarkeit)</de>
             <fr>[EN] Enable time, XP, and special events</fr>
             <pl>[EN] Enable time, XP, and special events</pl>
             <es>[EN] Enable time, XP, and special events</es>
@@ -812,18 +815,18 @@
             <ru>[EN] Living World</ru>
         </text>
         <text name="helpLine_rwe_ov1_intro_text">
-            <en>Random World Events brings dynamic, unpredictable events to your farm. 53 unique events across five categories fire automatically during play, affecting your economy, vehicles, fields, wildlife, and more. No two playthroughs will feel the same.</en>
-            <uk>Випадкові світові події привносять динамічні та непередбачувані події на вашу ферму. 53 унікальні події у п'яти категоріях запускаються автоматично під час гри, впливаючи на економіку, техніку, поля, дику природу та багато іншого. Жодне проходження не буде схожим на попереднє.</uk>
-            <da>Random World Events bringer dynamiske og uforudsigelige hændelser til din gård. 53 unikke hændelser fordelt på fem kategorier udløses automatisk under spillet og påvirker din økonomi, dine køretøjer, marker, dyreliv og meget mere. Hver gennemspilning føles unik.</da>
+            <en>Random World Events brings dynamic, unpredictable events to your farm. 40 unique events across five categories fire automatically during play, affecting your economy, vehicles, fields, wildlife, and more. No two playthroughs will feel the same.</en>
+            <uk>Випадкові світові події привносять динамічні та непередбачувані події на вашу ферму. 40 унікальних подій у п'яти категоріях запускаються автоматично під час гри, впливаючи на економіку, техніку, поля, дику природу та багато іншого. Жодне проходження не буде схожим на попереднє.</uk>
+            <da>Random World Events bringer dynamiske og uforudsigelige hændelser til din gård. 40 unikke hændelser fordelt på fem kategorier udløses automatisk under spillet og påvirker din økonomi, dine køretøjer, marker, dyreliv og meget mere. Hver gennemspilning føles unik.</da>
         
-            <de>Zufällige Welteregnisse bringen dynamische, unvorhersagbare Ereignisse auf deine Farm. 53 einzigartige Ereignisse aus fünf Kategorien starten zufällig im Spiel und beeinflussen Wirtschaft, Fahrzeuge, Wildtiere und mehr. Kein Spieldurchlauf wird sich mehr gleich anfühlen.</de>
-            <fr>[EN] Random World Events brings dynamic, unpredictable events to your farm. 53 unique events across five categories fire automatically during play, affecting your economy, vehicles, fields, wildlife, and more. No two playthroughs will feel the same.</fr>
-            <pl>[EN] Random World Events brings dynamic, unpredictable events to your farm. 53 unique events across five categories fire automatically during play, affecting your economy, vehicles, fields, wildlife, and more. No two playthroughs will feel the same.</pl>
-            <es>[EN] Random World Events brings dynamic, unpredictable events to your farm. 53 unique events across five categories fire automatically during play, affecting your economy, vehicles, fields, wildlife, and more. No two playthroughs will feel the same.</es>
-            <it>[EN] Random World Events brings dynamic, unpredictable events to your farm. 53 unique events across five categories fire automatically during play, affecting your economy, vehicles, fields, wildlife, and more. No two playthroughs will feel the same.</it>
-            <cz>[EN] Random World Events brings dynamic, unpredictable events to your farm. 53 unique events across five categories fire automatically during play, affecting your economy, vehicles, fields, wildlife, and more. No two playthroughs will feel the same.</cz>
-            <br>[EN] Random World Events brings dynamic, unpredictable events to your farm. 53 unique events across five categories fire automatically during play, affecting your economy, vehicles, fields, wildlife, and more. No two playthroughs will feel the same.</br>
-            <ru>[EN] Random World Events brings dynamic, unpredictable events to your farm. 53 unique events across five categories fire automatically during play, affecting your economy, vehicles, fields, wildlife, and more. No two playthroughs will feel the same.</ru>
+            <de>Zufällige Welteregnisse bringen dynamische, unvorhersagbare Ereignisse auf deine Farm. 40 einzigartige Ereignisse aus fünf Kategorien starten zufällig im Spiel und beeinflussen Wirtschaft, Fahrzeuge, Wildtiere und mehr. Kein Spieldurchlauf wird sich mehr gleich anfühlen.</de>
+            <fr>[EN] Random World Events brings dynamic, unpredictable events to your farm. 40 unique events across five categories fire automatically during play, affecting your economy, vehicles, fields, wildlife, and more. No two playthroughs will feel the same.</fr>
+            <pl>[EN] Random World Events brings dynamic, unpredictable events to your farm. 40 unique events across five categories fire automatically during play, affecting your economy, vehicles, fields, wildlife, and more. No two playthroughs will feel the same.</pl>
+            <es>[EN] Random World Events brings dynamic, unpredictable events to your farm. 40 unique events across five categories fire automatically during play, affecting your economy, vehicles, fields, wildlife, and more. No two playthroughs will feel the same.</es>
+            <it>[EN] Random World Events brings dynamic, unpredictable events to your farm. 40 unique events across five categories fire automatically during play, affecting your economy, vehicles, fields, wildlife, and more. No two playthroughs will feel the same.</it>
+            <cz>[EN] Random World Events brings dynamic, unpredictable events to your farm. 40 unique events across five categories fire automatically during play, affecting your economy, vehicles, fields, wildlife, and more. No two playthroughs will feel the same.</cz>
+            <br>[EN] Random World Events brings dynamic, unpredictable events to your farm. 40 unique events across five categories fire automatically during play, affecting your economy, vehicles, fields, wildlife, and more. No two playthroughs will feel the same.</br>
+            <ru>[EN] Random World Events brings dynamic, unpredictable events to your farm. 40 unique events across five categories fire automatically during play, affecting your economy, vehicles, fields, wildlife, and more. No two playthroughs will feel the same.</ru>
         </text>
         <text name="helpLine_rwe_ov1_expect_title">
             <en>What to Expect</en>
@@ -840,18 +843,18 @@
             <ru>[EN] What to Expect</ru>
         </text>
         <text name="helpLine_rwe_ov1_expect_text">
-            <en>Events appear as HUD notifications and last for a configurable duration. Some grant bonuses (market booms, fuel refills, crop buffs), while others impose challenges (accidents, price crashes, stampedes). A cooldown timer prevents event spam.</en>
-            <uk>Події відображаються як сповіщення HUD і тривають налаштовуваний час. Деякі дають бонуси (підйоми на ринку, поповнення палива, підсилення врожаю), тоді як інші створюють труднощі (аварії, падіння цін, натовпи тварин). Таймер перерви запобігає надмірній кількості подій.</uk>
-            <da>Hændelser vises som HUD-notifikationer og varer i et tidsrum, du selv kan konfigurere. Nogle giver bonusser (markedsboom, brændstofpåfyldning, afgrødebonusser), mens andre skaber udfordringer (ulykker, prisstyrt, paniske dyreflokke). En cooldown-timer sikrer, at hændelser ikke spammer spillet.</da>
+            <en>Events appear as HUD notifications and last for a configurable duration. Some grant bonuses (market booms, subsidies, crop buffs), while others impose challenges (accidents, price crashes, disease scares). A cooldown timer prevents event spam.</en>
+            <uk>Події відображаються як сповіщення HUD і тривають налаштовуваний час. Деякі дають бонуси (підйоми на ринку, субсидії, підсилення врожаю), тоді як інші створюють труднощі (аварії, падіння цін, спалахи хвороб). Таймер перерви запобігає надмірній кількості подій.</uk>
+            <da>Hændelser vises som HUD-notifikationer og varer i et tidsrum, du selv kan konfigurere. Nogle giver bonusser (markedsboom, tilskud, afgrødebonusser), mens andre skaber udfordringer (ulykker, prisstyrt, sygdomsalarm). En cooldown-timer sikrer, at hændelser ikke spammer spillet.</da>
         
-            <de>Die Ereignisse starten mit einer HUD-Benachrichtigung und dauern für eine einstellbare Zeit an. Einige geben Boni (z.B. Marktnachfrage, Betankungen oder Erntebuffs), andere sorgen für Schwierigkeiten (z.B. Unfälle, Preiseinbrüche, wilde Tierherden). Eingebaute Timer verhindern, dass zu viele Ereignisse starten.</de>
-            <fr>[EN] Events appear as HUD notifications and last for a configurable duration. Some grant bonuses (market booms, fuel refills, crop buffs), while others impose challenges (accidents, price crashes, stampedes). A cooldown timer prevents event spam.</fr>
-            <pl>[EN] Events appear as HUD notifications and last for a configurable duration. Some grant bonuses (market booms, fuel refills, crop buffs), while others impose challenges (accidents, price crashes, stampedes). A cooldown timer prevents event spam.</pl>
-            <es>[EN] Events appear as HUD notifications and last for a configurable duration. Some grant bonuses (market booms, fuel refills, crop buffs), while others impose challenges (accidents, price crashes, stampedes). A cooldown timer prevents event spam.</es>
-            <it>[EN] Events appear as HUD notifications and last for a configurable duration. Some grant bonuses (market booms, fuel refills, crop buffs), while others impose challenges (accidents, price crashes, stampedes). A cooldown timer prevents event spam.</it>
-            <cz>[EN] Events appear as HUD notifications and last for a configurable duration. Some grant bonuses (market booms, fuel refills, crop buffs), while others impose challenges (accidents, price crashes, stampedes). A cooldown timer prevents event spam.</cz>
-            <br>[EN] Events appear as HUD notifications and last for a configurable duration. Some grant bonuses (market booms, fuel refills, crop buffs), while others impose challenges (accidents, price crashes, stampedes). A cooldown timer prevents event spam.</br>
-            <ru>[EN] Events appear as HUD notifications and last for a configurable duration. Some grant bonuses (market booms, fuel refills, crop buffs), while others impose challenges (accidents, price crashes, stampedes). A cooldown timer prevents event spam.</ru>
+            <de>Die Ereignisse starten mit einer HUD-Benachrichtigung und dauern für eine einstellbare Zeit an. Einige geben Boni (z.B. Marktnachfrage, Subventionen oder Erntebuffs), andere sorgen für Schwierigkeiten (z.B. Unfälle, Preiseinbrüche, Seuchenwarnungen). Eingebaute Timer verhindern, dass zu viele Ereignisse starten.</de>
+            <fr>[EN] Events appear as HUD notifications and last for a configurable duration. Some grant bonuses (market booms, subsidies, crop buffs), while others impose challenges (accidents, price crashes, disease scares). A cooldown timer prevents event spam.</fr>
+            <pl>[EN] Events appear as HUD notifications and last for a configurable duration. Some grant bonuses (market booms, subsidies, crop buffs), while others impose challenges (accidents, price crashes, disease scares). A cooldown timer prevents event spam.</pl>
+            <es>[EN] Events appear as HUD notifications and last for a configurable duration. Some grant bonuses (market booms, subsidies, crop buffs), while others impose challenges (accidents, price crashes, disease scares). A cooldown timer prevents event spam.</es>
+            <it>[EN] Events appear as HUD notifications and last for a configurable duration. Some grant bonuses (market booms, subsidies, crop buffs), while others impose challenges (accidents, price crashes, disease scares). A cooldown timer prevents event spam.</it>
+            <cz>[EN] Events appear as HUD notifications and last for a configurable duration. Some grant bonuses (market booms, subsidies, crop buffs), while others impose challenges (accidents, price crashes, disease scares). A cooldown timer prevents event spam.</cz>
+            <br>[EN] Events appear as HUD notifications and last for a configurable duration. Some grant bonuses (market booms, subsidies, crop buffs), while others impose challenges (accidents, price crashes, disease scares). A cooldown timer prevents event spam.</br>
+            <ru>[EN] Events appear as HUD notifications and last for a configurable duration. Some grant bonuses (market booms, subsidies, crop buffs), while others impose challenges (accidents, price crashes, disease scares). A cooldown timer prevents event spam.</ru>
         </text>
 
         <!-- Help page: Overview page 2 -->
@@ -942,11 +945,11 @@
             <ru>[EN] Economic Events</ru>
         </text>
         <text name="helpLine_rwe_cat1_good_title">
-            <en>Positive Events (11)</en>
-            <uk>Позитивні події (11)</uk>
-            <da>Positive hændelser (11)</da>
+            <en>Positive Events (10)</en>
+            <uk>Позитивні події (10)</uk>
+            <da>Positive hændelser (10)</da>
         
-            <de>11 positive Ereignisse</de>
+            <de>10 positive Ereignisse</de>
             <fr>[EN] Positive Events (11)</fr>
             <pl>[EN] Positive Events (11)</pl>
             <es>[EN] Positive Events (11)</es>
@@ -956,18 +959,18 @@
             <ru>[EN] Positive Events (11)</ru>
         </text>
         <text name="helpLine_rwe_cat1_good_text">
-            <en>Government subsidies, market booms, farmer donations, tax refunds, insurance payouts, export opportunities, seed discounts, fertilizer discounts, fuel discounts, equipment discounts, and price-fixing bonuses (temporary elevated sell prices). These events grant direct cash or temporary price bonuses.</en>
-            <uk>Державні субсидії, підйоми на ринку, пожертви фермерів, повернення податків, страхові виплати, експортні можливості, знижки на насіння, знижки на добрива, знижки на паливо, знижки на обладнання та цінові бонуси (тимчасово підвищені ціни продажу). Ці події надають пряму готівку або тимчасові цінові бонуси.</uk>
-            <da>Statslige tilskud, markedsboom, donationer fra landmænd, skatterefusioner, forsikringsudbetalinger, eksportmuligheder, rabatter på frø, rabatter på gødning, rabatter på brændstof, rabatter på udstyr samt bonusser fra prisfastsættelse (midlertidigt forhøjede salgspriser). Disse hændelser giver direkte kontanter eller midlertidige prisbonusser.</da>
+            <en>Government subsidies, market booms, farmer donations, tax refunds, insurance payouts, export opportunities, seed discounts, fertilizer discounts, equipment discounts, and price-fixing bonuses (temporary elevated sell prices). These events grant direct cash or temporary price bonuses.</en>
+            <uk>Державні субсидії, підйоми на ринку, пожертви фермерів, повернення податків, страхові виплати, експортні можливості, знижки на насіння, знижки на добрива, знижки на обладнання та цінові бонуси (тимчасово підвищені ціни продажу). Ці події надають пряму готівку або тимчасові цінові бонуси.</uk>
+            <da>Statslige tilskud, markedsboom, donationer fra landmænd, skatterefusioner, forsikringsudbetalinger, eksportmuligheder, rabatter på frø, rabatter på gødning, rabatter på udstyr samt bonusser fra prisfastsættelse (midlertidigt forhøjede salgspriser). Disse hændelser giver direkte kontanter eller midlertidige prisbonusser.</da>
         
-            <de>Staatliche Subventionen, Marktbooms, Spenden von Landwirten, Steuerrückerstattungen, Versicherungsleistungen, Exportmöglichkeiten, Saatgut-, Düngemittel-, Kraftstoff- und Geräterabatte sowie Preisbindungsprämien (vorübergehend erhöhte Verkaufspreise) können zu direkten Geldauszahlungen oder befristeten Preisboni führen.</de>
-            <fr>[EN] Government subsidies, market booms, farmer donations, tax refunds, insurance payouts, export opportunities, seed discounts, fertilizer discounts, fuel discounts, equipment discounts, and price-fixing bonuses (temporary elevated sell prices). These events grant direct cash or temporary price bonuses.</fr>
-            <pl>[EN] Government subsidies, market booms, farmer donations, tax refunds, insurance payouts, export opportunities, seed discounts, fertilizer discounts, fuel discounts, equipment discounts, and price-fixing bonuses (temporary elevated sell prices). These events grant direct cash or temporary price bonuses.</pl>
-            <es>[EN] Government subsidies, market booms, farmer donations, tax refunds, insurance payouts, export opportunities, seed discounts, fertilizer discounts, fuel discounts, equipment discounts, and price-fixing bonuses (temporary elevated sell prices). These events grant direct cash or temporary price bonuses.</es>
-            <it>[EN] Government subsidies, market booms, farmer donations, tax refunds, insurance payouts, export opportunities, seed discounts, fertilizer discounts, fuel discounts, equipment discounts, and price-fixing bonuses (temporary elevated sell prices). These events grant direct cash or temporary price bonuses.</it>
-            <cz>[EN] Government subsidies, market booms, farmer donations, tax refunds, insurance payouts, export opportunities, seed discounts, fertilizer discounts, fuel discounts, equipment discounts, and price-fixing bonuses (temporary elevated sell prices). These events grant direct cash or temporary price bonuses.</cz>
-            <br>[EN] Government subsidies, market booms, farmer donations, tax refunds, insurance payouts, export opportunities, seed discounts, fertilizer discounts, fuel discounts, equipment discounts, and price-fixing bonuses (temporary elevated sell prices). These events grant direct cash or temporary price bonuses.</br>
-            <ru>[EN] Government subsidies, market booms, farmer donations, tax refunds, insurance payouts, export opportunities, seed discounts, fertilizer discounts, fuel discounts, equipment discounts, and price-fixing bonuses (temporary elevated sell prices). These events grant direct cash or temporary price bonuses.</ru>
+            <de>Staatliche Subventionen, Marktbooms, Spenden von Landwirten, Steuerrückerstattungen, Versicherungsleistungen, Exportmöglichkeiten, Saatgut-, Düngemittel- und Geräterabatte sowie Preisbindungsprämien (vorübergehend erhöhte Verkaufspreise) können zu direkten Geldauszahlungen oder befristeten Preisboni führen.</de>
+            <fr>[EN] Government subsidies, market booms, farmer donations, tax refunds, insurance payouts, export opportunities, seed discounts, fertilizer discounts, equipment discounts, and price-fixing bonuses (temporary elevated sell prices). These events grant direct cash or temporary price bonuses.</fr>
+            <pl>[EN] Government subsidies, market booms, farmer donations, tax refunds, insurance payouts, export opportunities, seed discounts, fertilizer discounts, equipment discounts, and price-fixing bonuses (temporary elevated sell prices). These events grant direct cash or temporary price bonuses.</pl>
+            <es>[EN] Government subsidies, market booms, farmer donations, tax refunds, insurance payouts, export opportunities, seed discounts, fertilizer discounts, equipment discounts, and price-fixing bonuses (temporary elevated sell prices). These events grant direct cash or temporary price bonuses.</es>
+            <it>[EN] Government subsidies, market booms, farmer donations, tax refunds, insurance payouts, export opportunities, seed discounts, fertilizer discounts, equipment discounts, and price-fixing bonuses (temporary elevated sell prices). These events grant direct cash or temporary price bonuses.</it>
+            <cz>[EN] Government subsidies, market booms, farmer donations, tax refunds, insurance payouts, export opportunities, seed discounts, fertilizer discounts, equipment discounts, and price-fixing bonuses (temporary elevated sell prices). These events grant direct cash or temporary price bonuses.</cz>
+            <br>[EN] Government subsidies, market booms, farmer donations, tax refunds, insurance payouts, export opportunities, seed discounts, fertilizer discounts, equipment discounts, and price-fixing bonuses (temporary elevated sell prices). These events grant direct cash or temporary price bonuses.</br>
+            <ru>[EN] Government subsidies, market booms, farmer donations, tax refunds, insurance payouts, export opportunities, seed discounts, fertilizer discounts, equipment discounts, and price-fixing bonuses (temporary elevated sell prices). These events grant direct cash or temporary price bonuses.</ru>
         </text>
         <text name="helpLine_rwe_cat1_bad_title">
             <en>Negative Events (4)</en>
@@ -1014,11 +1017,11 @@
             <ru>[EN] Vehicle &amp; Field Events</ru>
         </text>
         <text name="helpLine_rwe_cat2_vehicle_title">
-            <en>Vehicle Events (8)</en>
-            <uk>Події з технікою (8)</uk>
-            <da>Køretøjshændelser (8)</da>
+            <en>Vehicle Events (4)</en>
+            <uk>Події з технікою (4)</uk>
+            <da>Køretøjshændelser (4)</da>
         
-            <de>8 Fahrzeugereignisse</de>
+            <de>4 Fahrzeugereignisse</de>
             <fr>[EN] Vehicle Events (8)</fr>
             <pl>[EN] Vehicle Events (8)</pl>
             <es>[EN] Vehicle Events (8)</es>
@@ -1028,18 +1031,18 @@
             <ru>[EN] Vehicle Events (8)</ru>
         </text>
         <text name="helpLine_rwe_cat2_vehicle_text">
-            <en>Speed boosts, free fuel refills, fuel leaks, minor accidents with repair bills, full fleet cleaning, visual upgrades, engine trouble (reduced power), and emergency repair bills. Most vehicle events target your currently controlled vehicle.</en>
-            <uk>Прискорення, безкоштовне поповнення палива, витік палива, дрібні аварії з рахунками за ремонт, повне чищення парку техніки, візуальні оновлення, проблеми з двигуном (знижена потужність) та екстрені рахунки за ремонт. Більшість подій з технікою стосуються транспортного засобу, яким ви керуєте.</uk>
-            <da>Hastighedsboosts, gratis brændstofpåfyldninger, brændstoflækager, mindre ulykker med reparationsregninger, rengøring af hele køretøjsflåden, visuelle opgraderinger, motorproblemer (reduceret kraft) samt akutte reparationsregninger. De fleste køretøjshændelser påvirker det køretøj, du aktuelt styrer.</da>
+            <en>Minor accidents with repair bills and emergency repair bills target your farm's machines. An opt-in arcade mode (Arcade Physics, default off) adds speed boosts and engine trouble, applied to your own vehicle only.</en>
+            <uk>Дрібні аварії з рахунками за ремонт та екстрені рахунки за ремонт стосуються техніки вашої ферми. Додатковий аркадний режим (Аркадна фізика, вимкнено за замовчуванням) додає прискорення та проблеми з двигуном, лише для вашої техніки.</uk>
+            <da>Mindre ulykker med reparationsregninger og akutte reparationsregninger rammer gårdens maskiner. En valgfri arkademodus (Arkade-fysik, slået fra som standard) tilføjer hastighedsboosts og motorproblemer, kun på dit eget køretøj.</da>
         
-            <de>Höhere Geschwindigkeiten, kostenlose Tankfüllungen, Kraftstofflecks, kleinere Unfälle mit Reparaturkosten, Komplettreinigung der Flotte, kostenlose Lackierungen, Motorprobleme (Leistungsverlust) und Rechnungen für Notfallreparaturen. Die meisten Fahrzeugereignisse betreffen das aktuell gesteuerte Fahrzeug.</de>
-            <fr>[EN] Speed boosts, free fuel refills, fuel leaks, minor accidents with repair bills, full fleet cleaning, visual upgrades, engine trouble (reduced power), and emergency repair bills. Most vehicle events target your currently controlled vehicle.</fr>
-            <pl>[EN] Speed boosts, free fuel refills, fuel leaks, minor accidents with repair bills, full fleet cleaning, visual upgrades, engine trouble (reduced power), and emergency repair bills. Most vehicle events target your currently controlled vehicle.</pl>
-            <es>[EN] Speed boosts, free fuel refills, fuel leaks, minor accidents with repair bills, full fleet cleaning, visual upgrades, engine trouble (reduced power), and emergency repair bills. Most vehicle events target your currently controlled vehicle.</es>
-            <it>[EN] Speed boosts, free fuel refills, fuel leaks, minor accidents with repair bills, full fleet cleaning, visual upgrades, engine trouble (reduced power), and emergency repair bills. Most vehicle events target your currently controlled vehicle.</it>
-            <cz>[EN] Speed boosts, free fuel refills, fuel leaks, minor accidents with repair bills, full fleet cleaning, visual upgrades, engine trouble (reduced power), and emergency repair bills. Most vehicle events target your currently controlled vehicle.</cz>
-            <br>[EN] Speed boosts, free fuel refills, fuel leaks, minor accidents with repair bills, full fleet cleaning, visual upgrades, engine trouble (reduced power), and emergency repair bills. Most vehicle events target your currently controlled vehicle.</br>
-            <ru>[EN] Speed boosts, free fuel refills, fuel leaks, minor accidents with repair bills, full fleet cleaning, visual upgrades, engine trouble (reduced power), and emergency repair bills. Most vehicle events target your currently controlled vehicle.</ru>
+            <de>Kleinere Unfälle mit Reparaturkosten und Rechnungen für Notfallreparaturen betreffen die Maschinen deiner Farm. Ein optionaler Arcade-Modus (Arcade-Physik, standardmäßig aus) fügt Geschwindigkeitsboosts und Motorprobleme hinzu, nur für dein eigenes Fahrzeug.</de>
+            <fr>[EN] Minor accidents with repair bills and emergency repair bills target your farm's machines. An opt-in arcade mode (Arcade Physics, default off) adds speed boosts and engine trouble, applied to your own vehicle only.</fr>
+            <pl>[EN] Minor accidents with repair bills and emergency repair bills target your farm's machines. An opt-in arcade mode (Arcade Physics, default off) adds speed boosts and engine trouble, applied to your own vehicle only.</pl>
+            <es>[EN] Minor accidents with repair bills and emergency repair bills target your farm's machines. An opt-in arcade mode (Arcade Physics, default off) adds speed boosts and engine trouble, applied to your own vehicle only.</es>
+            <it>[EN] Minor accidents with repair bills and emergency repair bills target your farm's machines. An opt-in arcade mode (Arcade Physics, default off) adds speed boosts and engine trouble, applied to your own vehicle only.</it>
+            <cz>[EN] Minor accidents with repair bills and emergency repair bills target your farm's machines. An opt-in arcade mode (Arcade Physics, default off) adds speed boosts and engine trouble, applied to your own vehicle only.</cz>
+            <br>[EN] Minor accidents with repair bills and emergency repair bills target your farm's machines. An opt-in arcade mode (Arcade Physics, default off) adds speed boosts and engine trouble, applied to your own vehicle only.</br>
+            <ru>[EN] Minor accidents with repair bills and emergency repair bills target your farm's machines. An opt-in arcade mode (Arcade Physics, default off) adds speed boosts and engine trouble, applied to your own vehicle only.</ru>
         </text>
         <text name="helpLine_rwe_cat2_field_title">
             <en>Field Events (10)</en>
@@ -1086,11 +1089,11 @@
             <ru>[EN] Special &amp; Wildlife Events</ru>
         </text>
         <text name="helpLine_rwe_cat3_special_title">
-            <en>Special Events (10)</en>
-            <uk>Особливі події (10)</uk>
-            <da>Særlige hændelser (10)</da>
+            <en>Special Events (4)</en>
+            <uk>Особливі події (4)</uk>
+            <da>Særlige hændelser (4)</da>
         
-            <de>10 Spezialereignisse</de>
+            <de>4 Spezialereignisse</de>
             <fr>[EN] Special Events (10)</fr>
             <pl>[EN] Special Events (10)</pl>
             <es>[EN] Special Events (10)</es>
@@ -1100,25 +1103,25 @@
             <ru>[EN] Special Events (10)</ru>
         </text>
         <text name="helpLine_rwe_cat3_special_text">
-            <en>Time acceleration and slowdown (affects in-game time scale), XP gain bonuses and penalties, money multipliers, equipment durability changes, better trade prices, and town festivals. Time events restore the original time scale when they end.</en>
-            <uk>Прискорення та уповільнення часу (впливає на масштаб ігрового часу), бонуси та штрафи до отримання досвіду, множники грошей, зміни міцності обладнання, кращі торгові ціни та міські фестивалі. Після закінчення часових подій відновлюється початковий масштаб часу.</uk>
-            <da>Tidsacceleration og -opbremsning (påvirker spillets tidsskala), bonusser og straf på XP-optjening, pengemultiplikatorer, ændringer i udstyrets holdbarhed, bedre handelspriser samt byfestivaler. Tidsrelaterede hændelser gendanner den oprindelige tidsskala, når de slutter.</da>
+            <en>Better trade prices, town festivals, and equipment durability changes (the last two only with the opt-in Arcade Physics mode). Time-warp, reputation and cash-trickle events have been retired.</en>
+            <uk>Кращі торгові ціни, міські фестивалі та зміни міцності обладнання (останні два лише в додатковому аркадному режимі). Події з часом, досвідом та грошовими потоками вилучено.</uk>
+            <da>Bedre handelspriser, byfestivaler og ændringer i udstyrets holdbarhed (de to sidste kun i den valgfrie arkademodus). Tids-, ry- og kontant-tricklehændelser er udfaset.</da>
         
-            <de>Zeitbeschleunigung und -verlangsamung (beeinflusst die Spielzeit), Boni und Mali beim EP-Gewinn, Geldmultiplikatoren, Änderungen der Ausrüstungshaltbarkeit, bessere Handelspreise und Stadtfeste. Zeitereignisse stellen nach ihrem Ende die ursprüngliche Zeit wieder her.</de>
-            <fr>[EN] Time acceleration and slowdown (affects in-game time scale), XP gain bonuses and penalties, money multipliers, equipment durability changes, better trade prices, and town festivals. Time events restore the original time scale when they end.</fr>
-            <pl>[EN] Time acceleration and slowdown (affects in-game time scale), XP gain bonuses and penalties, money multipliers, equipment durability changes, better trade prices, and town festivals. Time events restore the original time scale when they end.</pl>
-            <es>[EN] Time acceleration and slowdown (affects in-game time scale), XP gain bonuses and penalties, money multipliers, equipment durability changes, better trade prices, and town festivals. Time events restore the original time scale when they end.</es>
-            <it>[EN] Time acceleration and slowdown (affects in-game time scale), XP gain bonuses and penalties, money multipliers, equipment durability changes, better trade prices, and town festivals. Time events restore the original time scale when they end.</it>
-            <cz>[EN] Time acceleration and slowdown (affects in-game time scale), XP gain bonuses and penalties, money multipliers, equipment durability changes, better trade prices, and town festivals. Time events restore the original time scale when they end.</cz>
-            <br>[EN] Time acceleration and slowdown (affects in-game time scale), XP gain bonuses and penalties, money multipliers, equipment durability changes, better trade prices, and town festivals. Time events restore the original time scale when they end.</br>
-            <ru>[EN] Time acceleration and slowdown (affects in-game time scale), XP gain bonuses and penalties, money multipliers, equipment durability changes, better trade prices, and town festivals. Time events restore the original time scale when they end.</ru>
+            <de>Bessere Handelspreise, Stadtfeste und Änderungen der Ausrüstungshaltbarkeit (die letzten beiden nur im optionalen Arcade-Modus). Zeit-, EP- und Geld-Trickle-Ereignisse wurden entfernt.</de>
+            <fr>[EN] Better trade prices, town festivals, and equipment durability changes (the last two only with the opt-in Arcade Physics mode). Time-warp, reputation and cash-trickle events have been retired.</fr>
+            <pl>[EN] Better trade prices, town festivals, and equipment durability changes (the last two only with the opt-in Arcade Physics mode). Time-warp, reputation and cash-trickle events have been retired.</pl>
+            <es>[EN] Better trade prices, town festivals, and equipment durability changes (the last two only with the opt-in Arcade Physics mode). Time-warp, reputation and cash-trickle events have been retired.</es>
+            <it>[EN] Better trade prices, town festivals, and equipment durability changes (the last two only with the opt-in Arcade Physics mode). Time-warp, reputation and cash-trickle events have been retired.</it>
+            <cz>[EN] Better trade prices, town festivals, and equipment durability changes (the last two only with the opt-in Arcade Physics mode). Time-warp, reputation and cash-trickle events have been retired.</cz>
+            <br>[EN] Better trade prices, town festivals, and equipment durability changes (the last two only with the opt-in Arcade Physics mode). Time-warp, reputation and cash-trickle events have been retired.</br>
+            <ru>[EN] Better trade prices, town festivals, and equipment durability changes (the last two only with the opt-in Arcade Physics mode). Time-warp, reputation and cash-trickle events have been retired.</ru>
         </text>
         <text name="helpLine_rwe_cat3_wildlife_title">
-            <en>Wildlife Events (10)</en>
-            <uk>Події з дикою природою (10)</uk>
-            <da>Dyrelivshændelser (10)</da>
+            <en>Wildlife Events (8)</en>
+            <uk>Події з дикою природою (8)</uk>
+            <da>Dyrelivshændelser (8)</da>
         
-            <de>10 Wildtierereignisse</de>
+            <de>8 Wildtierereignisse</de>
             <fr>[EN] Wildlife Events (10)</fr>
             <pl>[EN] Wildlife Events (10)</pl>
             <es>[EN] Wildlife Events (10)</es>
@@ -1128,18 +1131,18 @@
             <ru>[EN] Wildlife Events (10)</ru>
         </text>
         <text name="helpLine_rwe_cat3_wildlife_text">
-            <en>Bird flocks, beneficial insects, wild stampedes, predator alerts, rabbit infestations, bee swarms, hunting season bonuses, livestock product bonuses and penalties, veterinary bills, and disease scares. Enable the Wildlife category to experience these.</en>
-            <uk>Зграї птахів, корисні комахи, дикі натовпи тварин, сповіщення про хижаків, нашестя кролів, рої бджіл, бонуси сезону полювання, бонуси та штрафи до продуктів тваринництва, ветеринарні рахунки та спалахи хвороб. Увімкніть категорію «Дика природа», щоб переживати ці події.</uk>
-            <da>Fugleflokke, nyttige insekter, vilde dyreflokke på flugt, rovdyrvarsler, kaninangreb, bisværme, bonusser i jagtsæsonen, bonusser og straf på husdyrprodukter, dyrlægeregninger samt sygdomsbekymringer. Aktivér kategorien Dyreliv for at opleve disse hændelser.</da>
+            <en>Livestock product bonuses and penalties, wolf sightings, bumper wool seasons, disease scares, feed shortages, veterinary payouts, and wildlife pest invasions. Feed shortages and veterinary payouts affect your account; the herd and field events are signals the sim systems react to.</en>
+            <uk>Бонуси та штрафи до продуктів тваринництва, спостереження вовків, щедрі вовняні сезони, спалахи хвороб, нестача кормів, ветеринарні виплати та нашестя шкідників. Нестача кормів і ветеринарні виплати впливають на ваш рахунок; події стада та полів є сигналами, на які реагують симуляційні системи.</uk>
+            <da>Bonusser og straf på husdyrprodukter, ulveobservationer, store uldsæsoner, sygdomsalarm, fodermangel, dyrlægeudbetalinger samt skadedyrsinvasioner. Fodermangel og dyrlægeudbetalinger påvirker din konto; besætnings- og markhændelser er signaler, som simuleringssystemerne reagerer på.</da>
         
-            <de>Vogelschwärme, nützliche Insekten, wilde Tierherden, Raubtierwarnungen, Kaninchenplagen, Bienenschwärme, Boni in der Jagdsaison, Boni und Mali bei der Viehprodukten, Tierarztkosten und Seuchenwarnungen. Diese Ereignisse sind nur aktiv, wenn die Einstellung Wildtiere aktiv ist.</de>
-            <fr>[EN] Bird flocks, beneficial insects, wild stampedes, predator alerts, rabbit infestations, bee swarms, hunting season bonuses, livestock product bonuses and penalties, veterinary bills, and disease scares. Enable the Wildlife category to experience these.</fr>
-            <pl>[EN] Bird flocks, beneficial insects, wild stampedes, predator alerts, rabbit infestations, bee swarms, hunting season bonuses, livestock product bonuses and penalties, veterinary bills, and disease scares. Enable the Wildlife category to experience these.</pl>
-            <es>[EN] Bird flocks, beneficial insects, wild stampedes, predator alerts, rabbit infestations, bee swarms, hunting season bonuses, livestock product bonuses and penalties, veterinary bills, and disease scares. Enable the Wildlife category to experience these.</es>
-            <it>[EN] Bird flocks, beneficial insects, wild stampedes, predator alerts, rabbit infestations, bee swarms, hunting season bonuses, livestock product bonuses and penalties, veterinary bills, and disease scares. Enable the Wildlife category to experience these.</it>
-            <cz>[EN] Bird flocks, beneficial insects, wild stampedes, predator alerts, rabbit infestations, bee swarms, hunting season bonuses, livestock product bonuses and penalties, veterinary bills, and disease scares. Enable the Wildlife category to experience these.</cz>
-            <br>[EN] Bird flocks, beneficial insects, wild stampedes, predator alerts, rabbit infestations, bee swarms, hunting season bonuses, livestock product bonuses and penalties, veterinary bills, and disease scares. Enable the Wildlife category to experience these.</br>
-            <ru>[EN] Bird flocks, beneficial insects, wild stampedes, predator alerts, rabbit infestations, bee swarms, hunting season bonuses, livestock product bonuses and penalties, veterinary bills, and disease scares. Enable the Wildlife category to experience these.</ru>
+            <de>Boni und Mali bei den Viehprodukten, Wolfsichtungen, üppige Wollzeiten, Seuchenwarnungen, Futtermangel, Tierarztzahlungen und Schädlingsinvasionen. Futtermangel und Tierarztzahlungen wirken auf dein Konto; Herden- und Feldereignisse sind Signale, auf die die Simulationssysteme reagieren.</de>
+            <fr>[EN] Livestock product bonuses and penalties, wolf sightings, bumper wool seasons, disease scares, feed shortages, veterinary payouts, and wildlife pest invasions. Feed shortages and veterinary payouts affect your account; the herd and field events are signals the sim systems react to.</fr>
+            <pl>[EN] Livestock product bonuses and penalties, wolf sightings, bumper wool seasons, disease scares, feed shortages, veterinary payouts, and wildlife pest invasions. Feed shortages and veterinary payouts affect your account; the herd and field events are signals the sim systems react to.</pl>
+            <es>[EN] Livestock product bonuses and penalties, wolf sightings, bumper wool seasons, disease scares, feed shortages, veterinary payouts, and wildlife pest invasions. Feed shortages and veterinary payouts affect your account; the herd and field events are signals the sim systems react to.</es>
+            <it>[EN] Livestock product bonuses and penalties, wolf sightings, bumper wool seasons, disease scares, feed shortages, veterinary payouts, and wildlife pest invasions. Feed shortages and veterinary payouts affect your account; the herd and field events are signals the sim systems react to.</it>
+            <cz>[EN] Livestock product bonuses and penalties, wolf sightings, bumper wool seasons, disease scares, feed shortages, veterinary payouts, and wildlife pest invasions. Feed shortages and veterinary payouts affect your account; the herd and field events are signals the sim systems react to.</cz>
+            <br>[EN] Livestock product bonuses and penalties, wolf sightings, bumper wool seasons, disease scares, feed shortages, veterinary payouts, and wildlife pest invasions. Feed shortages and veterinary payouts affect your account; the herd and field events are signals the sim systems react to.</br>
+            <ru>[EN] Livestock product bonuses and penalties, wolf sightings, bumper wool seasons, disease scares, feed shortages, veterinary payouts, and wildlife pest invasions. Feed shortages and veterinary payouts affect your account; the herd and field events are signals the sim systems react to.</ru>
         </text>
 
         <!-- Help page: Settings / event settings -->
@@ -1514,6 +1517,64 @@
             <uk>[F3]: перемкнути   ПКМ: рух/розмір</uk>
             <ru>[F3]: переключить   ПКМ: переместить/размер</ru>
             <da>[F3]: slå til/fra Højreklik: flyt/ændr størrelse</da>
+        </text>
+
+        <!-- Arcade physics opt-in (redesign, default OFF) -->
+        <text name="rwe_arcade_physics_short">
+            <en>Arcade Physics</en>
+            <de>Arcade-Physik</de>
+            <fr>Physique arcade</fr>
+            <nl>Arcade-fysica</nl>
+            <it>Fisica arcade</it>
+            <pl>Fizyka zręcznościowa</pl>
+            <es>Física arcade</es>
+            <ea>Física arcade</ea>
+            <pt>Física arcade</pt>
+            <br>Física arcade</br>
+            <ru>Аркадная физика</ru>
+            <uk>Аркадна фізика</uk>
+            <cz>Arkádová fyzika</cz>
+            <hu>Arkád fizika</hu>
+            <ro>Fizică arcade</ro>
+            <tr>Arcade Fizik</tr>
+            <fi>Arcade-fysiikka</fi>
+            <no>Arcade-fysikk</no>
+            <sv>Arcade-fysik</sv>
+            <da>Arkade-fysik</da>
+            <kr>아케이드 물리</kr>
+            <jp>アーケード物理</jp>
+            <ct>街機物理</ct>
+            <fc>街机物理</fc>
+            <id>Fisika arkade</id>
+            <vi>Vật lý arcade</vi>
+        </text>
+        <text name="rwe_arcade_physics_long">
+            <en>Allow arcade vehicle-physics events (player vehicle only, default off)</en>
+            <de>Arcade-Fahrzeugphysik-Ereignisse erlauben (nur eigenes Fahrzeug, standardmäßig aus)</de>
+            <fr>Autoriser les événements de physique de véhicule arcade (véhicule du joueur uniquement, désactivé par défaut)</fr>
+            <nl>Arcade-voertuigfysica-gebeurtenissen toestaan (alleen eigen voertuig, standaard uit)</nl>
+            <it>Consenti eventi di fisica di veicolo arcade (solo veicolo del giocatore, disattivati per impostazione predefinita)</it>
+            <pl>Zezwól na arkadowe zdarzenia fizyki pojazdów (tylko pojazd gracza, domyślnie wyłączone)</pl>
+            <es>Permitir eventos de física de vehículos arcade (solo el vehículo del jugador, desactivado por defecto)</es>
+            <ea>Permitir eventos de física de vehículos arcade (solo el vehículo del jugador, desactivado por defecto)</ea>
+            <pt>Permitir eventos de física de veículos arcade (apenas o veículo do jogador, desativado por padrão)</pt>
+            <br>Permitir eventos de física de veículos arcade (apenas o veículo do jogador, desativado por padrão)</br>
+            <ru>Разрешить аркадные события физики техники (только техника игрока, по умолчанию выключено)</ru>
+            <uk>Дозволити аркадні події фізики техніки (лише техніка гравця, вимкнено за замовчуванням)</uk>
+            <cz>Povolit arkádové události fyziky vozidel (pouze vozidlo hráče, ve výchozím nastavení vypnuto)</cz>
+            <hu>Arkád járműfizika-események engedélyezése (csak a játékos járműve, alapból kikapcsolva)</hu>
+            <ro>Permiteți evenimente arcade de fizică a vehiculelor (doar vehiculul jucătorului, dezactivat implicit)</ro>
+            <tr>Arcade araç fizik olaylarına izin ver (yalnızca oyuncu aracı, varsayılan olarak kapalı)</tr>
+            <fi>Salli arcade-ajoneuvofysiikkatapahtumat (vain pelaajan ajoneuvo, oletuksena pois päältä)</fi>
+            <no>Tillat arkade-kjøretøysfysikkhendelser (kun spillerens kjøretøy, av som standard)</no>
+            <sv>Tillåt arkadfordonsfysikhändelser (endast spelarens fordon, av som standard)</sv>
+            <da>Tillad arkade-køretøjsfysikbegivenheder (kun spillerens køretøj, slået fra som standard)</da>
+            <kr>아케이드 차량 물리 이벤트 허용 (플레이어 차량만, 기본적으로 꺼짐)</kr>
+            <jp>アーケード車両物理イベントを許可（プレイヤー車両のみ、デフォルトはオフ）</jp>
+            <ct>允許街機車輛物理事件（僅限玩家車輛，默認關閉）</ct>
+            <fc>允许街机车辆物理事件（仅限玩家车辆，默认关闭）</fc>
+            <id>Izinkan peristiwa fisika kendaraan arkade (hanya kendaraan pemain, nonaktif secara default)</id>
+            <vi>Cho phép sự kiện vật lý xe arcade (chỉ xe của người chơi, tắt mặc định)</vi>
         </text>
     </l10n>
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.1.8.0</version>
+    <version>2.1.8.1</version>
     <modName>FS25_RandomWorldEvents</modName>
     <title>
         <en>Random World Events</en>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.1.8.0</version>
+    <version>2.1.8.2</version>
     <modName>FS25_RandomWorldEvents</modName>
     <title>
         <en>Random World Events</en>

--- a/tools/git-hooks/pre-commit
+++ b/tools/git-hooks/pre-commit
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Lua 5.1 syntax (+ repo lint where present) pre-commit gate.
+#
+# WHY THIS EXISTS: a Lua parse error does not stop FS25 loading the mod. The mod
+# loads, the game runs, and the offending FILE is silently dropped, so one feature
+# is simply absent with nothing but a single compiler line nobody reads. Two such
+# errors sat unnoticed in this suite until 2026-07-30 (FarmTablet's ProStaffApp and
+# WorkplaceTriggers' WTNetworkSyncBridge), each dead in EVERY session since it
+# shipped. Sub-second here beats a deploy plus a multi-minute load, and beats never
+# noticing at all.
+#
+# Install:   bash tools/test/install-hooks.sh
+# Skip once: git commit --no-verify
+# Remove:    rm "$(git rev-parse --git-path hooks)/pre-commit"
+set -e
+
+staged_lua="$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.lua$' || true)"
+[ -z "$staged_lua" ] && exit 0
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root/tools/test"
+[ -d node_modules ] || npm install --silent
+
+echo "pre-commit: Lua 5.1 syntax (staged)…"
+# Absolute paths, NUL-safe against spaces in the repo path.
+printf '%s\n' "$staged_lua" | while IFS= read -r f; do
+  [ -n "$f" ] && printf '%s\0' "$repo_root/$f"
+done | xargs -0 node ./check-staged.mjs
+
+# Repo-wide lint pass on top, when the repo has one. Non-fatal to keep the gate's
+# job crisp: syntax blocks, style advises.
+if node -e "process.exit(require('./package.json').scripts.lint ? 0 : 1)" 2>/dev/null; then
+  npm run --silent lint || echo "  (lint reported findings; not blocking the commit)"
+fi

--- a/tools/test/check-staged.mjs
+++ b/tools/test/check-staged.mjs
@@ -1,0 +1,52 @@
+// Parse the exact files git is about to commit, with luaparse pinned to Lua 5.1.
+//
+// WHY NOT REUSE tools/test/syntax-check.mjs: its findLuaFiles() defaults to SRC_DIR,
+// so it never sees main.lua at the repo root - the entry point of several mods in this
+// suite. A gate that misses the entry file is worse than no gate, because it grants
+// false confidence. This checks the STAGED set instead, which is by definition exactly
+// what is shipping, wherever it lives in the tree.
+//
+// Lives in tools/test/ (not tools/git-hooks/) because node resolves bare imports from
+// the SCRIPT's directory upward - from tools/git-hooks it never sees tools/test/node_modules.
+// Usage: node check-staged.mjs <abs-path>...
+import { readFileSync } from "node:fs";
+import luaparse from "luaparse";
+
+const files = process.argv.slice(2);
+let bad = 0;
+for (const f of files) {
+  let code;
+  try {
+    code = readFileSync(f, "utf8");
+  } catch {
+    continue; // deleted or moved between staging and now; nothing to parse
+  }
+
+  // A UTF-8 BOM is caught by the parse below, but only as
+  // "Cannot read properties of undefined (reading 'range')", which tells you
+  // nothing. Name it explicitly instead. Lua does not skip a byte order mark
+  // the way it skips a shebang, so U+FEFF is read as part of the first token.
+  // Seven files across four repos hit this on 2026-08-05, all from an editor
+  // saving as "UTF-8 with BOM".
+  if (code.charCodeAt(0) === 0xfeff) {
+    bad++;
+    console.error(`  \u2717 ${f}`);
+    console.error("      Starts with a UTF-8 BOM (EF BB BF). Lua 5.1 cannot parse it.");
+    console.error("      Fix: re-save as UTF-8 WITHOUT BOM, or strip the 3 leading bytes.");
+    continue;
+  }
+
+  try {
+    luaparse.parse(code, { luaVersion: "5.1", comments: false, locations: true });
+  } catch (e) {
+    bad++;
+    console.error(`  \u2717 ${f}\n      ${e.message}`);
+  }
+}
+if (bad > 0) {
+  console.error(`\n  ${bad} staged Lua file(s) will NOT compile in FS25. Commit blocked.`);
+  console.error("  FS25 drops the whole file at load with no useful message, so this");
+  console.error("  would ship as a silently missing feature. Fix, or --no-verify.");
+  process.exit(1);
+}
+console.log(`  \u2713 Lua 5.1 syntax OK - ${files.length} staged file(s)`);

--- a/tools/test/package.json
+++ b/tools/test/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "description": "Lua 5.1 pre-commit gate. Excluded from the mod zip with the rest of tools/.",
   "devDependencies": {
+    "fengari": "^0.1.4",
     "luaparse": "^0.3.1"
   }
 }

--- a/tools/test/package.json
+++ b/tools/test/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "fs25_randomworldevents-checks",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Lua 5.1 pre-commit gate. Excluded from the mod zip with the rest of tools/.",
+  "devDependencies": {
+    "luaparse": "^0.3.1"
+  }
+}

--- a/tools/test/rwe-redesign-bench.mjs
+++ b/tools/test/rwe-redesign-bench.mjs
@@ -1,0 +1,247 @@
+// RWE redesign (non-price half) bench.
+//
+// Two layers, both runnable here:
+//   A. The vendored OptionScalingResolver (pure library, byte-identical to the
+//      SettingsHub spine branch) executed in a real Lua 5.1 VM (fengari):
+//      OFF/absent == neutral, canonical World-events curve anchors, switch off.
+//   B. Structural assertions over the ACTUAL source files (luaparse): the 13
+//      cut events are gone, the 4 arcade-physics events carry the toggle gate,
+//      the field/animal money trickle handlers are removed, the reputation
+//      write is gone, the price patch no longer reads the read-signal flags,
+//      the damage patch is arcade-gated, and the core read/difficulty surface
+//      is present.
+//
+// The mod has no in-engine test harness; this is the stand-in. Usage:
+//   node tools/test/rwe-redesign-bench.mjs <repo-root>
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import luaparse from "luaparse";
+
+const ROOT = process.argv[2] || ".";
+let pass = 0;
+let failCount = 0;
+const ok = (msg) => { pass++; console.log(`  \u2713 ${msg}`); };
+const fail = (msg) => { failCount++; console.error(`  \u2717 ${msg}`); };
+
+// ---------------------------------------------------------------------------
+// A. Resolver contract in a real Lua 5.1 VM
+// ---------------------------------------------------------------------------
+try {
+  const { lua, lauxlib, lualib, to_luastring } = await import("fengari");
+  const L = lauxlib.luaL_newstate();
+  lualib.luaL_openlibs(L);
+
+  const resolverSrc = readFileSync(join(ROOT, "utils/OptionScalingResolver.lua"), "utf8");
+  if (lauxlib.luaL_loadstring(L, to_luastring(resolverSrc)) !== 0 || lua.lua_pcall(L, 0, 0, 0) !== 0) {
+    throw new Error("resolver failed to load in the Lua VM: " + lua.lua_tostring(L, -1));
+  }
+
+  // runExpr evaluates a Lua body that can build a mock settingsHub with set()
+  // and call OptionScalingResolver.readProfile/resolve. Returns true/false.
+  const runExpr = (body) => {
+    const code = `local R = OptionScalingResolver
+      local store = {}
+      local function val(self, module, key)
+        if module ~= R.MODULE then return nil end
+        if key == R.PRESET_KEY then return store.preset or "standard" end
+        if key:match("^dial_") then return store.dials and store.dials[key:sub(6)] end
+        if key:match("^switch_") then return store.switches and store.switches[key:sub(8)] end
+        return nil
+      end
+      local hub = { getValue = val }
+      local function set(dials, switches, preset)
+        store.dials = dials; store.switches = switches; store.preset = preset or "standard"
+      end
+      return (${body})`;
+    const rc = lauxlib.luaL_dostring(L, to_luastring(code));
+    if (rc !== 0) throw new Error("lua eval failed: " + lua.lua_tostring(L, -1));
+    const res = lua.lua_toboolean(L, -1);
+    lua.lua_pop(L, 1);
+    return res;
+  };
+
+  const A1 = runExpr(`(function()
+    local prof = OptionScalingResolver.readProfile(nil)
+    if prof ~= nil then return false end
+    local v = OptionScalingResolver.resolve({ dial = "worldEvents", base = 1.0, neutral = 1.0 }, prof)
+    if v ~= 1.0 then return false end
+    local v2 = OptionScalingResolver.resolve({ dial = "worldEvents", base = 1.0, neutral = 1.0 }, {})
+    return v2 == 1.0
+  end)()`);
+  A1 ? ok("resolver: absent spine resolves to declared neutral (1.0)") : fail("resolver: neutral contract broken");
+
+  const A2 = runExpr(`(function()
+    local R = OptionScalingResolver
+    local decl = { dial = "worldEvents", base = 1.0, neutral = 1.0 }
+    set({ worldEvents = 0.0 }, { worldEvents = true })
+    local r0 = R.resolve(decl, R.readProfile(hub))
+    set({ worldEvents = 1.0 }, { worldEvents = true })
+    local r1 = R.resolve(decl, R.readProfile(hub))
+    set({ worldEvents = 2.0 }, { worldEvents = true })
+    local r2 = R.resolve(decl, R.readProfile(hub))
+    return math.abs(r0 - 0.4) < 1e-9 and math.abs(r1 - 1.0) < 1e-9 and math.abs(r2 - 1.7) < 1e-9
+  end)()`);
+  A2 ? ok("resolver: worldEvents canonical curve anchors 0.4/1.0/1.7") : fail("resolver: worldEvents curve anchors wrong");
+
+  const A3 = runExpr(`(function()
+    local R = OptionScalingResolver
+    set({ economy = 2.0 }, { economy = true })
+    local v = R.resolve({ dial = "economy", base = 1.0, neutral = 1.0 }, R.readProfile(hub))
+    return math.abs(v - 1.8) < 1e-9
+  end)()`);
+  A3 ? ok("resolver: economy canonical curve anchor 1.8 at punishing") : fail("resolver: economy curve anchor wrong");
+
+  const A4 = runExpr(`(function()
+    local R = OptionScalingResolver
+    set({ worldEvents = 2.0 }, { worldEvents = false })
+    local v = R.resolve({ dial = "worldEvents", base = 1.0, neutral = 1.0 }, R.readProfile(hub))
+    return v == 1.0
+  end)()`);
+  A4 ? ok("resolver: switched-off dial resolves to neutral") : fail("resolver: switch-off not neutral");
+
+  const A5 = runExpr(`(function()
+    local R = OptionScalingResolver
+    local decl = { dial = "worldEvents", base = 1.0, neutral = 1.0 }
+    set({ worldEvents = 2.0 }, { worldEvents = true })
+    local d = R.readProfile(hub)
+    local factor = R.resolve(decl, d)
+    local ef = math.max(1, math.min(10, math.floor(5 * factor)))
+    local ei = math.max(1, math.min(5, math.floor(2 * factor)))
+    if ef ~= 8 or ei ~= 3 then return false end
+    local nf = math.max(1, math.min(10, math.floor(5 * 1.0)))
+    local ni = math.max(1, math.min(5, math.floor(2 * 1.0)))
+    return nf == 5 and ni == 2
+  end)()`);
+  A5 ? ok("wrapper math: punishing scales freq 5->8, intensity 2->3; neutral keeps 5/2") : fail("wrapper math wrong");
+} catch (e) {
+  fail("resolver bench failed: " + e.message);
+}
+
+// ---------------------------------------------------------------------------
+// B. Structural assertions over the real source
+// ---------------------------------------------------------------------------
+const src = (rel) => readFileSync(join(ROOT, rel), "utf8");
+const parse = (rel) => luaparse.parse(src(rel), { luaVersion: "5.1", comments: false, locations: true });
+
+const CUT = [
+  "time_acceleration", "time_slowdown", "bonus_xp", "malus_xp", "money_bonus",
+  "money_malus", "vehicle_fuel_bonus", "vehicle_fuel_penalty",
+  "vehicle_free_upgrade", "vehicle_cleaning_bonus", "vehicle_steering_pull",
+  "vehicle_slippery_roads", "fuel_discount",
+];
+const TOGGLE = [
+  "vehicle_speed_boost", "vehicle_engine_trouble",
+  "equipment_durability_boost", "equipment_durability_drop",
+];
+
+// luaparse gives StringLiteral.value = null (only .raw is set), so unquote raw.
+const unquote = (str) => (typeof str === "string" && str.startsWith("\"")) ? str.slice(1, -1) : str;
+
+// Walk every TableConstructorExpression, yielding each entry's
+// { name = string|nil, gate = string|nil } as keyed by its literal fields.
+function tableEntries(ast) {
+  const out = [];
+  (function walk(node) {
+    if (!node || typeof node !== "object") return;
+    if (node.type === "TableConstructorExpression") {
+      const entry = { name: undefined, gate: undefined };
+      for (const f of node.fields || []) {
+        if (f.type !== "TableKeyString") continue;
+        const keyName = f.key && f.key.name;
+        if ((keyName === "name" || keyName === "gate") && f.value && f.value.type === "StringLiteral") {
+          entry[keyName] = unquote(f.value.raw);
+        }
+      }
+      if (entry.name !== undefined) out.push(entry);
+    }
+    for (const k of Object.keys(node)) walk(node[k]);
+  })(ast);
+  return out;
+}
+
+// Collect the string values of every `name = "..."` field inside a module.
+function eventNames(rel) {
+  return tableEntries(parse(rel)).map((e) => e.name);
+}
+
+// Find the `gate = "..."` value of a named event, if any.
+function gateOf(rel, eventName) {
+  const entry = tableEntries(parse(rel)).find((e) => e.name === eventName);
+  return entry ? entry.gate : undefined;
+}
+
+const modules = [
+  ["utils/specialEvents.lua", "special"],
+  ["utils/economicEvents.lua", "economic"],
+  ["utils/fieldEvents.lua", "field"],
+  ["utils/animalEvents.lua", "wildlife"],
+  ["utils/vehicleEvents.lua", "vehicle"],
+];
+
+const allNames = modules.flatMap(([rel]) => eventNames(rel));
+const stillPresent = CUT.filter((c) => allNames.includes(c));
+stillPresent.length === 0
+  ? ok(`structural: none of the ${CUT.length} cut events remain registered`)
+  : fail(`structural: cut events still registered: ${stillPresent.join(", ")}`);
+
+const ungated = TOGGLE.filter((t) => gateOf("utils/" + (t.startsWith("vehicle") ? "vehicleEvents.lua" : "specialEvents.lua"), t) !== "arcadePhysics");
+ungated.length === 0
+  ? ok("structural: all 4 arcade-physics events carry gate=arcadePhysics")
+  : fail(`structural: toggle events missing gate: ${ungated.join(", ")}`);
+
+const fieldSrc = src("utils/fieldEvents.lua");
+const animalSrc = src("utils/animalEvents.lua");
+(!/fieldTickHandler/.test(fieldSrc) && !/registerTickHandler\("fieldEvents"/.test(fieldSrc))
+  ? ok("structural: field money-trickle handler removed")
+  : fail("structural: field tick handler still present");
+(!/animalTickHandler/.test(animalSrc) && !/registerTickHandler\("animalEvents"/.test(animalSrc))
+  ? ok("structural: animal money-trickle handler removed")
+  : fail("structural: animal tick handler still present");
+
+const specialSrc = src("utils/specialEvents.lua");
+!/repPoints/.test(specialSrc)
+  ? ok("structural: reputation (repPoints) write removed")
+  : fail("structural: repPoints still written in specialEvents");
+
+const hooks = src("utils/EffectHooks.lua");
+!/s\.yieldBonus|s\.yieldMalus/.test(hooks)
+  ? ok("structural: read-signal flags removed from the price patch")
+  : fail("structural: yieldBonus/yieldMalus still read by the price patch");
+(/allowsArcadePhysics/.test(hooks) && /g_localPlayer/.test(hooks))
+  ? ok("structural: damage patch gated behind arcadePhysics + player-vehicle scope")
+  : fail("structural: damage patch not gated or not player-scoped");
+
+const core = src("RandomWorldEvents.lua");
+const need = ["getIntensity", "isEventActive", "getProgress", "getRemainingTime", "getDifficulty", "allowsArcadePhysics", "getEffectiveFrequency", "getBaseIntensity", 'event.gate == "arcadePhysics"'];
+const missing = need.filter((n) => !core.includes(n));
+missing.length === 0
+  ? ok("structural: core read-surface + difficulty + toggle gate present")
+  : fail(`structural: core missing: ${missing.join(", ")}`);
+
+const hubBridge = src("integrations/RWESettingsHubBridge.lua");
+const esc = src("gui/RWESettingsIntegration.lua");
+const panel = src("gui/RWESettingsPanel.lua");
+(hubBridge.includes("arcadePhysics") && esc.includes("onRWEArcadePhysicsChanged") && panel.includes("Arcade Physics"))
+  ? ok("structural: arcadePhysics exposed in SettingsHub, ESC and quick panel")
+  : fail("structural: arcadePhysics not exposed in all settings surfaces");
+
+const resolverSrc = src("utils/OptionScalingResolver.lua");
+(resolverSrc.includes("OptionScalingResolver.CONTRACT_VERSION = 1") && resolverSrc.includes('"worldEvents"'))
+  ? ok("structural: vendored OptionScalingResolver present (contract v1)")
+  : fail("structural: vendored resolver missing or contract drift");
+
+const counts = {};
+for (const [rel, key] of modules) counts[key] = new Set(eventNames(rel)).size;
+const total = Object.values(counts).reduce((a, b) => a + b, 0);
+if (counts.economic === 14 && counts.field === 10 && counts.vehicle === 4 && counts.wildlife === 8 && counts.special === 4 && total === 40) {
+  ok(`structural: event catalog = 40 (economic ${counts.economic}, field ${counts.field}, vehicle ${counts.vehicle}, wildlife ${counts.wildlife}, special ${counts.special})`);
+} else {
+  fail(`structural: unexpected catalog ${JSON.stringify(counts)} (total ${total})`);
+}
+
+console.log(`\n[bench] passed: ${pass}, failed: ${failCount}`);
+if (failCount > 0) {
+  console.error("[bench] FAILED");
+  process.exit(1);
+}
+console.log("[bench] PASSED");

--- a/utils/EffectHooks.lua
+++ b/utils/EffectHooks.lua
@@ -45,9 +45,10 @@ if EconomyManager and EconomyManager.getPricePerLiter then
             mult = mult * (1 - s.economicCrisis.marketMalus)
         end
 
-        -- Field modifiers
-        if s.yieldBonus     then mult = mult * (1 + s.yieldBonus)     end
-        if s.yieldMalus     then mult = mult * (1 - s.yieldMalus)     end
+        -- Field price modifiers (harvest / field-sale stay here until the
+        -- MarketDynamics re-home lands; crop_yield and wildlife_pest are now
+        -- PULL read-signals owned by the sim systems, so yieldBonus/yieldMalus
+        -- no longer scale sell prices).
         if s.harvestBonus   then mult = mult * (1 + s.harvestBonus)   end
         if s.harvestMalus   then mult = mult * (1 - s.harvestMalus)   end
         if s.fieldSaleBonus then mult = mult * (1 + s.fieldSaleBonus) end
@@ -87,8 +88,11 @@ end
 
 -- =====================
 -- VEHICLE DAMAGE HOOK
--- Patches Vehicle.addDamageAmount to scale incoming damage
--- based on durability EVENT_STATE flags.
+-- Patches Vehicle.addDamageAmount to scale incoming damage based on the
+-- durability EVENT_STATE flags. Redesign: this global patch only acts behind
+-- the arcadePhysics opt-in toggle (default OFF), and even then only for the
+-- player's own vehicle. When the toggle is OFF the patch is a transparent
+-- pass-through so normal gameplay damage is never touched.
 -- =====================
 if Vehicle and Vehicle.addDamageAmount then
     local origAddDamage = Vehicle.addDamageAmount
@@ -98,6 +102,21 @@ if Vehicle and Vehicle.addDamageAmount then
             return origAddDamage(self, damage, ...)
         end
         if not g_RandomWorldEvents then
+            return origAddDamage(self, damage, ...)
+        end
+        if not g_RandomWorldEvents:allowsArcadePhysics() then
+            return origAddDamage(self, damage, ...)
+        end
+
+        -- Never scale damage on an NPC-driven vehicle.
+        local isPlayerVehicle = false
+        local p = g_localPlayer
+        if p ~= nil and p.getCurrentVehicle ~= nil then
+            isPlayerVehicle = p:getCurrentVehicle() == self
+        elseif g_currentMission ~= nil then
+            isPlayerVehicle = g_currentMission.controlledVehicle == self
+        end
+        if not isPlayerVehicle then
             return origAddDamage(self, damage, ...)
         end
 
@@ -113,7 +132,7 @@ if Vehicle and Vehicle.addDamageAmount then
         return origAddDamage(self, scaledDamage, ...)
     end
 
-    Logging.info("[EffectHooks] Vehicle.addDamageAmount hooked")
+    Logging.info("[EffectHooks] Vehicle.addDamageAmount hooked (arcade-physics gate)")
 else
     Logging.info("[EffectHooks] Vehicle.addDamageAmount not available in this build — durability scaling disabled")
 end

--- a/utils/OptionScalingResolver.lua
+++ b/utils/OptionScalingResolver.lua
@@ -1,0 +1,252 @@
+-- =========================================================
+-- FS25_SettingsHub - Option-Scaling Resolver (the pure library)
+-- =========================================================
+-- Author: TisonK
+-- Governance: cross-suite AUTHORITY #1 (Arissani design, SDS v2.0 seven-dial,
+--   co-signed 2026-07-18). Brief: ecosystem-dev-tracking/systems/option-scaling-spine/
+-- =========================================================
+-- THE VENDORED HALF of the Option-Scaling Spine. This file is PURE: it depends
+-- on nothing but standard Lua and a duck-typed settingsHub handle. It is meant
+-- to be copied verbatim into every consumer mod, so the KEY CONTRACT (the module
+-- id, the dial names, the value-key shapes) lives here and stays identical
+-- across the whole suite by being the same source in every clone.
+--
+-- The SettingsHub-side profile module (OptionScalingSpine.lua) uses these same
+-- constants to register the admin settings, so the writer and every reader agree
+-- on the wire names by construction.
+--
+-- What a consumer does with this file:
+--   1. DECLARE each scalable value once:
+--        { id, dial, base, curve = {at0,at1,at2,ease}, clampMin, clampMax, neutral }
+--   2. READ the profile once per resolve point:
+--        local profile = OptionScalingResolver.readProfile(g_currentMission.settingsHub)
+--   3. RESOLVE:
+--        local eff = OptionScalingResolver.resolve(decl, profile)
+--   ...and treat OFF / absent as neutral. Never write back.
+--
+-- OFF == NOT-INSTALLED == NEUTRAL is the load-bearing contract: an absent hub, an
+-- unregistered profile, or a switched-off dial all resolve to the declared
+-- neutral, so a system can be turned fully off and the game still plays.
+-- =========================================================
+
+OptionScalingResolver = {}
+
+-- Bump only on a wire-contract change (a renamed dial, a new key shape). A
+-- consumer can compare this against its vendored copy to detect drift.
+OptionScalingResolver.CONTRACT_VERSION = 1
+
+-- The SettingsHub module id the profile registers under. Readers pass this to
+-- getValue; it must match OptionScalingSpine.MODULE exactly.
+OptionScalingResolver.MODULE = "OptionScalingSpine"
+
+-- The seven dials, in canonical order. Each has one float (intensity) and one
+-- bool (its on/off switch) in the profile module.
+OptionScalingResolver.DIALS = {
+    "economy", "labor", "agronomy", "biological",
+    "livestock", "worldEvents", "community",
+}
+
+-- Intensity band. A dial float runs 0..2 with 1.0 the neutral midpoint, so a
+-- curve whose at1 is 1.0 produces a neutral multiplier at the Standard preset.
+-- The exact band and the per-curve endpoints are the ratio pass (BACKLOG-20);
+-- these are the structural defaults, not balance.
+OptionScalingResolver.INTENSITY_MIN     = 0.0
+OptionScalingResolver.INTENSITY_MAX     = 2.0
+OptionScalingResolver.INTENSITY_NEUTRAL = 1.0
+
+-- The CANONICAL curve per dial, filled by the ratio pass (BACKLOG-20 v0.2,
+-- 2026-07-22, Arissani + ClaudeA). Written directly on this framework's 0..2
+-- intensity axis: at0 at dial 0 (Relaxed), at1 = 1.0 at dial 1 (Standard =
+-- neutral = identity), at2 at dial 2 (Punishing). A consumer that declares a
+-- value on a dial without supplying its own curve gets the dial's canonical
+-- curve. These anchors are balance and belong to the ratio pass; the framework
+-- only carries them so every consumer scales the dial the same way.
+OptionScalingResolver.DIAL_CURVES = {
+    economy     = { at0 = 0.4, at1 = 1.0, at2 = 1.8 },
+    labor       = { at0 = 0.6, at1 = 1.0, at2 = 1.5 },
+    agronomy    = { at0 = 0.7, at1 = 1.0, at2 = 1.4 },
+    biological  = { at0 = 0.5, at1 = 1.0, at2 = 1.6 },
+    livestock   = { at0 = 0.5, at1 = 1.0, at2 = 1.6 },
+    worldEvents = { at0 = 0.4, at1 = 1.0, at2 = 1.7 },
+    community   = { at0 = 0.8, at1 = 1.0, at2 = 1.3 },
+}
+
+-- The Economy dial carries a SECOND curve, C5 escape-hatch pricing (ratio pass
+-- BACKLOG-20): the recovery hatches (disease flush, emergency loan, feed flush)
+-- read the SAME economy intensity through a steeper curve, so a hatch always
+-- stings more than an everyday cost. A hatch pricer declares its value on the
+-- economy dial with curve = ECONOMY_HATCH_CURVE; resolve() honours a per
+-- declaration curve. On Punishing everyday economy runs 1.8x while a hatch runs
+-- 2.75x off the one Economy intensity; even on Relaxed a hatch is 0.2x, not free.
+OptionScalingResolver.ECONOMY_HATCH_CURVE = { at0 = 0.2, at1 = 1.0, at2 = 2.75 }
+
+-- The canonical curve for a dial, or nil for an unknown dial.
+function OptionScalingResolver.dialCurve(dial)
+    return OptionScalingResolver.DIAL_CURVES[dial]
+end
+
+-- Value-key builders, so the writer and readers never hand-type a key.
+function OptionScalingResolver.dialKey(dial)   return "dial_" .. dial end
+function OptionScalingResolver.switchKey(dial) return "switch_" .. dial end
+OptionScalingResolver.PRESET_KEY = "preset"
+
+-- Preset enum values + a coarse difficulty rank for the tuning-tool gate. The
+-- authoritative preset set (ratio pass BACKLOG-20, Arissani + ClaudeA 2026-07-22):
+-- four named presets ordered by bite (Relaxed, Standard, Realistic, Punishing)
+-- plus Custom. Standard sits second of four, the 1.0 identity, with two harder
+-- presets above it; the ordering delivers Arissani's "Standard sits lower-middle"
+-- intent without moving the neutral point. "custom" ranks at Standard so a hand
+-- tuned world does not silently unlock the tuning tools.
+OptionScalingResolver.PRESETS = { "relaxed", "standard", "realistic", "punishing", "custom" }
+OptionScalingResolver.PRESET_RANK = {
+    relaxed = 0, standard = 1, realistic = 2, punishing = 3, custom = 1,
+}
+OptionScalingResolver.DEFAULT_PRESET = "standard"
+
+-- Each named preset maps to ONE intensity on the 0..2 dial axis (ratio pass
+-- BACKLOG-20). Applying a preset sets every dial to this intensity, and each
+-- dial's own curve then yields its multiplier, so one slider position means the
+-- right thing suite-wide. Standard is the 1.0 identity; Realistic sits three
+-- quarters of the way from Standard to Punishing. Custom is absent here: the
+-- player sets each dial by hand.
+OptionScalingResolver.PRESET_INTENSITY = {
+    relaxed = 0.0, standard = 1.0, realistic = 1.5, punishing = 2.0,
+}
+
+-- The intensity a named preset sets on every dial, or nil for Custom / unknown.
+function OptionScalingResolver.intensityForPreset(preset)
+    return OptionScalingResolver.PRESET_INTENSITY[preset]
+end
+
+-- The tuning-tool gate threshold (ratio pass BACKLOG-20): tools are available
+-- BELOW this rank and blocked at it and above. Threshold 1 with the ranks above
+-- means available on Relaxed only (rank 0), blocked at Standard and up, the
+-- authoritative gate: a difficulty-bypass tool belongs only to the deliberate
+-- easy setting, never the engaged-player default.
+OptionScalingResolver.TOOL_GATE_THRESHOLD = 1  -- available on Relaxed only
+
+-- =========================================================
+-- Pure math
+-- =========================================================
+
+local function clampNumber(v, lo, hi)
+    if lo ~= nil and v < lo then v = lo end
+    if hi ~= nil and v > hi then v = hi end
+    return v
+end
+
+-- Evaluate a curve at an intensity. A curve is three anchor factors at intensity
+-- 0 / 1 / 2 with an optional ease exponent, interpolated piecewise:
+--   x <= 1 : between at0 and at1
+--   x  > 1 : between at1 and at2
+-- ease shapes the segment (1 = linear, >1 = slow start, <1 = fast start). A nil
+-- curve, or nil anchors, default to 1.0 so a missing curve is a neutral one.
+function OptionScalingResolver.curveEval(curve, x)
+    if type(x) ~= "number" then x = OptionScalingResolver.INTENSITY_NEUTRAL end
+    x = clampNumber(x, OptionScalingResolver.INTENSITY_MIN, OptionScalingResolver.INTENSITY_MAX)
+
+    if type(curve) ~= "table" then return 1.0 end
+    local at0  = curve.at0  or 1.0
+    local at1  = curve.at1  or 1.0
+    local at2  = curve.at2  or 1.0
+    local ease = curve.ease or 1.0
+
+    local a, b, t
+    if x <= 1.0 then
+        a, b, t = at0, at1, x
+    else
+        a, b, t = at1, at2, x - 1.0
+    end
+    if ease ~= 1.0 and t > 0 then t = t ^ ease end
+    return a + (b - a) * t
+end
+
+-- =========================================================
+-- Profile reads (duck-typed over any settingsHub with :getValue)
+-- =========================================================
+
+-- Is the whole spine present? getValue returns nil for an unregistered module,
+-- so a nil preset means the profile never registered (spine not installed) and
+-- every read must fall to neutral.
+local function spinePresent(settingsHub)
+    if settingsHub == nil or type(settingsHub.getValue) ~= "function" then return false end
+    return settingsHub:getValue(OptionScalingResolver.MODULE, OptionScalingResolver.PRESET_KEY) ~= nil
+end
+
+-- Read the current profile into a plain table the resolver consumes:
+--   { dials = { dial -> intensity }, switches = { dial -> bool }, preset = str }
+-- Returns nil when the spine is absent, which every consumer treats as neutral.
+function OptionScalingResolver.readProfile(settingsHub)
+    if not spinePresent(settingsHub) then return nil end
+
+    local dials, switches = {}, {}
+    for _, dial in ipairs(OptionScalingResolver.DIALS) do
+        local intensity = settingsHub:getValue(OptionScalingResolver.MODULE, OptionScalingResolver.dialKey(dial))
+        local sw        = settingsHub:getValue(OptionScalingResolver.MODULE, OptionScalingResolver.switchKey(dial))
+        dials[dial]    = (type(intensity) == "number") and intensity or OptionScalingResolver.INTENSITY_NEUTRAL
+        switches[dial] = sw ~= false   -- nil (unset) reads as on
+    end
+
+    local preset = settingsHub:getValue(OptionScalingResolver.MODULE, OptionScalingResolver.PRESET_KEY)
+    return { dials = dials, switches = switches, preset = preset }
+end
+
+-- Is a dial switched on? A nil profile or a nil switch table means the spine is
+-- absent, which is OFF for every dial. A present profile defaults an unset dial
+-- switch to on.
+function OptionScalingResolver.isDialOn(profile, dial)
+    if profile == nil or profile.switches == nil then return false end
+    return profile.switches[dial] ~= false
+end
+
+-- =========================================================
+-- The resolve + the neutral contract
+-- =========================================================
+
+-- The declared neutral for a value, defaulting to 1.0 (a multiplier). A consumer
+-- declaring an addend sets neutral = 0. Status / collection reads are not scalars
+-- and do not go through resolve(): the consumer gates those on isDialOn() and
+-- returns nil / {} itself.
+function OptionScalingResolver.neutralOf(decl)
+    if decl ~= nil and decl.neutral ~= nil then return decl.neutral end
+    return 1.0
+end
+
+-- Turn (declaration, profile) into an effective scalar.
+--   effective = clamp( base * curveEval(curve, dialIntensity), clampMin, clampMax )
+-- OFF / absent short-circuits to the declared neutral BEFORE any math, so no
+-- half-arrived profile can produce a non-neutral value.
+function OptionScalingResolver.resolve(decl, profile)
+    if type(decl) ~= "table" then return 1.0 end
+    local neutral = OptionScalingResolver.neutralOf(decl)
+
+    if profile == nil then return neutral end
+    if not OptionScalingResolver.isDialOn(profile, decl.dial) then return neutral end
+
+    local intensity = profile.dials and profile.dials[decl.dial]
+    if type(intensity) ~= "number" then intensity = OptionScalingResolver.INTENSITY_NEUTRAL end
+
+    local base   = decl.base or 1.0
+    -- A declaration may supply its own curve; otherwise the dial's canonical
+    -- ratio-pass curve applies, so consumers scale a dial consistently.
+    local curve  = decl.curve or OptionScalingResolver.DIAL_CURVES[decl.dial]
+    local factor = OptionScalingResolver.curveEval(curve, intensity)
+    local eff    = base * factor
+    return clampNumber(eff, decl.clampMin, decl.clampMax)
+end
+
+-- =========================================================
+-- The tuning-tool difficulty gate (a consumer of the profile)
+-- =========================================================
+
+-- Should a tuning / bypass tool be available under this profile? A nil profile
+-- (spine absent) returns true, so a tool falls back to its own local gate rather
+-- than being locked by a spine that is not there. Otherwise the preset rank is
+-- compared to the threshold: available strictly below it, blocked at and above.
+function OptionScalingResolver.isToolAllowed(profile, threshold)
+    if profile == nil then return true end
+    threshold = threshold or OptionScalingResolver.TOOL_GATE_THRESHOLD
+    local rank = OptionScalingResolver.PRESET_RANK[profile.preset]
+    if rank == nil then rank = OptionScalingResolver.PRESET_RANK[OptionScalingResolver.DEFAULT_PRESET] end
+    return rank < threshold
+end

--- a/utils/animalEvents.lua
+++ b/utils/animalEvents.lua
@@ -202,36 +202,15 @@ animalEvents.eventList = {
 }
 
 -- =====================
--- TICK HANDLER
--- Delivers per-minute cash effects for active animal bonuses/maluses.
--- =====================
-local function animalTickHandler(rwe)
-    if not g_currentMission then return end
-    local s = rwe.EVENT_STATE
-    local t = g_currentMission.time
-    local lastTick = s.lastAnimalTick or 0
-    if t - lastTick < 60000 then return end
-    s.lastAnimalTick = t
-
-    local farmId = g_currentMission.player and g_currentMission.player.farmId or 0
-    if farmId == 0 then return end
-
-    local amount = 0
-    if s.animalProductBonus then
-        amount = amount + math.floor(400 * s.animalProductBonus)
-    end
-    if s.animalProductMalus then
-        amount = amount - math.floor(300 * s.animalProductMalus)
-    end
-
-    if amount ~= 0 and g_currentMission.addMoney then
-        rweAddMoney(amount, farmId, MoneyType.OTHER, false)
-    end
-end
-
--- =====================
 -- REGISTER ANIMAL EVENTS
 -- =====================
+-- The herd/product events (animal_product_bonus/penalty, wolf_sighting,
+-- bumper_wool_season, disease_scare, wildlife_pest_invasion) are PULL
+-- read-signals in the redesign: DairyCore / CropDisease read them via the
+-- companion surface and apply their own herd/disease/pest response. The old
+-- per-60-second money trickle for these flags is CUT (cash-from-nowhere).
+-- feed_shortage and veterinary_windfall keep their money movements until the
+-- TaxMod onDayChange settlement lands (the gated money half).
 local function registerAnimalEvents()
     if not g_RandomWorldEvents or not g_RandomWorldEvents.registerEvent then
         Logging.warning("[AnimalEvents] g_RandomWorldEvents not available yet")
@@ -257,14 +236,11 @@ local function registerAnimalEvents()
                     s.woolBonusSeason    = nil
                     s.diseaseScare       = nil
                     s.yieldMalus         = 0
-                    s.lastAnimalTick     = nil
                 end
                 return nil
             end
         })
     end
-
-    g_RandomWorldEvents:registerTickHandler("animalEvents", animalTickHandler)
 
     Logging.info("[AnimalEvents] Registered " .. #animalEvents.eventList .. " wildlife/animal events")
     return true

--- a/utils/economicEvents.lua
+++ b/utils/economicEvents.lua
@@ -140,23 +140,6 @@ economicEvents.eventList = {
     },
 
     {
-        name="fuel_discount", minI=1,
-        func=function(intensity)
-            if g_RandomWorldEvents then
-                g_RandomWorldEvents.EVENT_STATE.fuelDiscount = 0.1 + 0.05 * intensity
-            end
-            return string.format("Fuel prices drop! -%.0f%% at the pump today.", (0.1 + 0.05 * intensity) * 100)
-        end,
-        onMid = function(intensity)
-            return "Fuel's still cheap — keep those engines running."
-        end,
-        ambientMsgs = {
-            "Crude oil glut on global markets is trickling down to farm diesel.",
-            "The local fuel supplier is matching the regional price drop.",
-        },
-    },
-
-    {
         name="equipment_discount", minI=1,
         func=function(intensity)
             if g_RandomWorldEvents then
@@ -302,10 +285,6 @@ local function economicTickHandler(rwe)
         local savings = math.floor(400 * s.fertilizerDiscount)
         amount = amount + savings
     end
-    if s.fuelDiscount then
-        local savings = math.floor(300 * s.fuelDiscount)
-        amount = amount + savings
-    end
     if s.equipmentDiscount then
         local savings = math.floor(350 * s.equipmentDiscount)
         amount = amount + savings
@@ -348,7 +327,6 @@ local function registerEconomicEvents()
                     s.marketMalus        = nil
                     s.seedDiscount       = nil
                     s.fertilizerDiscount = nil
-                    s.fuelDiscount       = nil
                     s.equipmentDiscount  = nil
                     s.priceFixing        = nil
                     s.exportBonus        = nil

--- a/utils/fieldEvents.lua
+++ b/utils/fieldEvents.lua
@@ -194,33 +194,14 @@ fieldEvents.eventList = {
 }
 
 -- =====================
--- TICK HANDLER
--- =====================
-local function fieldTickHandler(rwe)
-    if not g_currentMission then return end
-    local s = rwe.EVENT_STATE
-    local t = g_currentMission.time
-    local lastTick = s.lastFieldTick or 0
-    if t - lastTick < 60000 then return end
-    s.lastFieldTick = t
-
-    local farmId = g_currentMission.player and g_currentMission.player.farmId or 0
-    if farmId == 0 then return end
-
-    local amount = 0
-    if s.fertilizerBonus then amount = amount + math.floor(500 * s.fertilizerBonus) end
-    if s.fertilizerMalus then amount = amount - math.floor(400 * s.fertilizerMalus) end
-    if s.seedBonus       then amount = amount + math.floor(300 * s.seedBonus)       end
-    if s.seedMalus       then amount = amount - math.floor(250 * s.seedMalus)       end
-
-    if amount ~= 0 and g_currentMission.addMoney then
-        rweAddMoney(amount, farmId, MoneyType.OTHER, false)
-    end
-end
-
--- =====================
 -- REGISTER FIELD EVENTS
 -- =====================
+-- The crop/fertilizer/seed-growth events are PULL read-signals in the redesign:
+-- RWE sets the EVENT_STATE flags and the owning sim system (SoilFertilizer /
+-- CropDisease) reads them via getActiveEvent / getSubsystem("field") and applies
+-- its own model. The old per-60-second money trickle for these flags is CUT
+-- (cash-from-nowhere); harvest and field-sale price effects stay in EffectHooks
+-- until the MarketDynamics re-home lands (the gated price half).
 local function registerFieldEvents()
     if not g_RandomWorldEvents or not g_RandomWorldEvents.registerEvent then
         Logging.warning("[FieldEvents] g_RandomWorldEvents not available yet")
@@ -257,14 +238,11 @@ local function registerFieldEvents()
                     s.harvestMalus    = nil
                     s.fieldSaleBonus  = nil
                     s.fieldSaleMalus  = nil
-                    s.lastFieldTick   = nil
                 end
                 return nil
             end
         })
     end
-
-    g_RandomWorldEvents:registerTickHandler("fieldEvents", fieldTickHandler)
 
     Logging.info("[FieldEvents] Registered " .. #fieldEvents.eventList .. " field events")
     return true

--- a/utils/specialEvents.lua
+++ b/utils/specialEvents.lua
@@ -18,112 +18,6 @@ end
 
 specialEvents.eventList = {
     {
-        name="time_acceleration", minI=1,
-        func=function(intensity)
-            if not g_RandomWorldEvents then return "Time is moving faster!" end
-            if not g_RandomWorldEvents.EVENT_STATE.originalTimeScale then
-                g_RandomWorldEvents.EVENT_STATE.originalTimeScale = g_currentMission.missionInfo.timeScale
-            end
-            g_currentMission.missionInfo.timeScale = g_RandomWorldEvents.EVENT_STATE.originalTimeScale * (5 * intensity)
-            return string.format("Time warp! The clock is running %.0fx faster.", 5 * intensity)
-        end,
-        onMid = function(intensity)
-            return string.format("Still in fast-forward — time running at %.0fx. Plan ahead.", 5 * intensity)
-        end,
-        ambientMsgs = {
-            "The hours are blurring together. Sunrises come fast.",
-            "Day and night are cycling like a strobe. Get as much done as you can.",
-        },
-    },
-
-    {
-        name="time_slowdown", minI=1,
-        func=function(intensity)
-            if not g_RandomWorldEvents then return "Time is slowing down!" end
-            if not g_RandomWorldEvents.EVENT_STATE.originalTimeScale then
-                g_RandomWorldEvents.EVENT_STATE.originalTimeScale = g_currentMission.missionInfo.timeScale
-            end
-            g_currentMission.missionInfo.timeScale = g_RandomWorldEvents.EVENT_STATE.originalTimeScale / (2 * intensity)
-            return string.format("Time dilation! Every hour feels like %.0f.", 2 * intensity)
-        end,
-        onMid = function(intensity)
-            return "Time is still crawling. Plenty of hours left — make them count."
-        end,
-        ambientMsgs = {
-            "The sun seems to hang in the sky for ages today.",
-            "You can hear every insect in the field. Time feels stretched.",
-        },
-    },
-
-    {
-        name="bonus_xp", minI=1,
-        func=function(intensity)
-            if g_RandomWorldEvents then
-                g_RandomWorldEvents.EVENT_STATE.xpBonus = 0.1 * intensity
-            end
-            return string.format("Reputation surge! +%.0f%% rep gain.", (0.1 * intensity) * 100)
-        end,
-        onMid = function(intensity)
-            return string.format("Still earning reputation faster — +%.0f%% ongoing.", (0.1 * intensity) * 100)
-        end,
-        ambientMsgs = {
-            "Word's getting around about your operation. People are impressed.",
-            "The local paper mentioned your farm. Good publicity.",
-        },
-    },
-
-    {
-        name="malus_xp", minI=1,
-        func=function(intensity)
-            if g_RandomWorldEvents then
-                g_RandomWorldEvents.EVENT_STATE.xpMalus = 0.1 * intensity
-            end
-            return string.format("Reputation dip! -%.0f%% rep gain for a while.", (0.1 * intensity) * 100)
-        end,
-        onMid = function(intensity)
-            return "Reputation still recovering — keep your head down and work hard."
-        end,
-        ambientMsgs = {
-            "Someone complained to the co-op. Best keep a low profile.",
-            "A dispute with a neighbour is doing the rounds in town.",
-        },
-    },
-
-    {
-        name="money_bonus", minI=1,
-        func=function(intensity)
-            if g_RandomWorldEvents then
-                g_RandomWorldEvents.EVENT_STATE.moneyBonus = 0.1 * intensity
-            end
-            return string.format("Cash flowing! +€%d extra income per minute.", math.floor(500 * 0.1 * intensity))
-        end,
-        onMid = function(intensity)
-            return string.format("Income boost still active — +€%d/min trickling in.", math.floor(500 * 0.1 * intensity))
-        end,
-        ambientMsgs = {
-            "The farm account is ticking upward. A good stretch.",
-            "Contracts and side deals are paying out today.",
-        },
-    },
-
-    {
-        name="money_malus", minI=1,
-        func=function(intensity)
-            if g_RandomWorldEvents then
-                g_RandomWorldEvents.EVENT_STATE.moneyMalus = 0.1 * intensity
-            end
-            return string.format("Unexpected costs! -€%d per minute for a while.", math.floor(400 * 0.1 * intensity))
-        end,
-        onMid = function(intensity)
-            return string.format("Costs still bleeding — -€%d/min. Sit tight.", math.floor(400 * 0.1 * intensity))
-        end,
-        ambientMsgs = {
-            "Administration fees, permit renewals... it adds up fast.",
-            "The accountant flagged a few unexpected charges this period.",
-        },
-    },
-
-    {
         name="special_event_festival", minI=1,
         func=function(intensity)
             if g_RandomWorldEvents then
@@ -147,7 +41,7 @@ specialEvents.eventList = {
     },
 
     {
-        name="equipment_durability_boost", minI=1,
+        name="equipment_durability_boost", minI=1, gate="arcadePhysics",
         func=function(intensity)
             if g_RandomWorldEvents then
                 g_RandomWorldEvents.EVENT_STATE.durabilityBoost = 0.15 + 0.05 * intensity
@@ -164,7 +58,7 @@ specialEvents.eventList = {
     },
 
     {
-        name="equipment_durability_drop", minI=1,
+        name="equipment_durability_drop", minI=1, gate="arcadePhysics",
         func=function(intensity)
             if g_RandomWorldEvents then
                 g_RandomWorldEvents.EVENT_STATE.durabilityMalus = 0.15 + 0.05 * intensity
@@ -213,26 +107,14 @@ local function specialTickHandler(rwe)
     local farmId = g_currentMission.player and g_currentMission.player.farmId or 0
     if farmId == 0 then return end
 
+    -- The harvest festival's income trickle is the only money this handler
+    -- carries now (money_bonus/money_malus and the reputation events are cut;
+    -- reputation belongs to NPCFavor). Gated server-side as before.
     local amount = 0
     if s.moneyBonus then amount = amount + math.floor(500 * s.moneyBonus) end
-    if s.moneyMalus then amount = amount - math.floor(400 * s.moneyMalus) end
 
     if amount ~= 0 and g_currentMission.addMoney then
         rweAddMoney(amount, farmId, MoneyType.OTHER, false)
-    end
-
-    -- Server-authoritative reputation: like rweAddMoney above, rep writes must
-    -- only run on the server or clients would apply the change locally too.
-    if (s.xpBonus or s.xpMalus) and g_farmManager and g_currentMission:getIsServer() then
-        local farm = g_farmManager:getFarmById(farmId)
-        if farm and farm.repPoints ~= nil then
-            if s.xpBonus then
-                farm.repPoints = farm.repPoints + math.floor(10 * s.xpBonus)
-            end
-            if s.xpMalus then
-                farm.repPoints = math.max(0, farm.repPoints - math.floor(8 * s.xpMalus))
-            end
-        end
     end
 end
 
@@ -259,14 +141,7 @@ local function registerSpecialEvents()
             onEnd = function()
                 if g_RandomWorldEvents then
                     local s = g_RandomWorldEvents.EVENT_STATE
-                    if s.originalTimeScale then
-                        g_currentMission.missionInfo.timeScale = s.originalTimeScale
-                        s.originalTimeScale = nil
-                    end
-                    s.xpBonus         = nil
-                    s.xpMalus         = nil
                     s.moneyBonus      = nil
-                    s.moneyMalus      = nil
                     s.durabilityBoost = nil
                     s.durabilityMalus = nil
                     s.tradeBonus      = nil

--- a/utils/vehicleEvents.lua
+++ b/utils/vehicleEvents.lua
@@ -79,70 +79,6 @@ vehicleEvents.restoreTrackedPhysics = function()
 end
 
 -- =====================
--- VEHICLE FUEL SYSTEM (real FS25 FillUnit API)
--- The old code used getFillUnitInformation()/setFillUnitFillLevel() which do
--- not exist in FS25 - the events did nothing. The correct path (per the game's
--- own VehicleSystem) is getConsumerFillUnitIndex() to find the fuel tank, then
--- addFillUnitFillLevel(farmId, index, delta, fillType, toolType, ...).
--- =====================
-
--- Collect the vehicle's fuel/consumable fill-unit indices (diesel / electric /
--- methane / DEF). Returns a list of fill-unit indices.
-vehicleEvents.getFuelFillUnits = function(vehicle)
-    local units = {}
-    if not vehicle or vehicle.getConsumerFillUnitIndex == nil then return units end
-    local fuelTypes = { FillType.DIESEL, FillType.ELECTRICCHARGE, FillType.METHANE, FillType.DEF }
-    for _, ft in ipairs(fuelTypes) do
-        if ft ~= nil then
-            local idx = vehicle:getConsumerFillUnitIndex(ft)
-            if idx ~= nil then
-                table.insert(units, idx)
-            end
-        end
-    end
-    return units
-end
-
-vehicleEvents.fillVehicleFuel = function(vehicle)
-    if not vehicle then return 0 end
-    local farmId = vehicleEvents.getFarmId()
-    if farmId <= 0 then return 0 end
-    local filled = 0
-    for _, idx in ipairs(vehicleEvents.getFuelFillUnits(vehicle)) do
-        local capacity = vehicle:getFillUnitCapacity(idx)
-        local level    = vehicle:getFillUnitFillLevel(idx)
-        local fillType = vehicle:getFillUnitFirstSupportedFillType(idx)
-        if capacity and level and fillType and fillType ~= FillType.UNKNOWN then
-            local toFill = capacity - level
-            if toFill > 0 then
-                vehicle:addFillUnitFillLevel(farmId, idx, toFill, fillType, ToolType.UNDEFINED, nil)
-                filled = filled + toFill
-            end
-        end
-    end
-    return filled
-end
-
-vehicleEvents.drainVehicleFuel = function(vehicle, percentage)
-    if not vehicle then return 0 end
-    local farmId = vehicleEvents.getFarmId()
-    if farmId <= 0 then return 0 end
-    local drained = 0
-    for _, idx in ipairs(vehicleEvents.getFuelFillUnits(vehicle)) do
-        local level    = vehicle:getFillUnitFillLevel(idx)
-        local fillType = vehicle:getFillUnitFirstSupportedFillType(idx)
-        if level and fillType and fillType ~= FillType.UNKNOWN then
-            local toDrain = level * (percentage / 100)
-            if toDrain > 0 then
-                vehicle:addFillUnitFillLevel(farmId, idx, -toDrain, fillType, ToolType.UNDEFINED, nil)
-                drained = drained + toDrain
-            end
-        end
-    end
-    return drained
-end
-
--- =====================
 -- VEHICLE DAMAGE SYSTEM (real: Wearable API)
 -- Note: vehicle damage also reduces engine torque and top speed natively
 -- (getTorqueCurveValue / getSpeedLimit apply a damage factor), so an
@@ -179,6 +115,7 @@ vehicleEvents.eventList = {
     {
         name = "vehicle_speed_boost",
         minI = 1,
+        gate = "arcadePhysics",
         func = function(intensity)
             local vehicle = vehicleEvents.getVehicle()
             if vehicle and RWEVehiclePhysics then
@@ -200,43 +137,6 @@ vehicleEvents.eventList = {
             "The engine note is higher than usual - everything feels responsive today.",
             "You're covering ground fast. The fields won't know what hit them.",
             "Neighbours are asking what you put in the tank. It's a good day to work.",
-        },
-    },
-
-    {
-        name = "vehicle_fuel_bonus",
-        minI = 1,
-        func = function(intensity)
-            local vehicle = vehicleEvents.getVehicle()
-            if vehicle then
-                local filledAmount = vehicleEvents.fillVehicleFuel(vehicle)
-                if filledAmount > 0 then
-                    return string.format("Mystery fuel delivery! Tanks topped up (+%.1fL).", filledAmount)
-                end
-                return "Free fuel - tanks were already full."
-            end
-            return "Free fuel waiting - get in a vehicle!"
-        end,
-    },
-
-    {
-        name = "vehicle_fuel_penalty",
-        minI = 1,
-        func = function(intensity)
-            local vehicle = vehicleEvents.getVehicle()
-            if vehicle then
-                local drainPercent = 20 + (intensity * 10)
-                local drainedAmount = vehicleEvents.drainVehicleFuel(vehicle, drainPercent)
-                if drainedAmount > 0 then
-                    return string.format("Fuel leak! %.0fL drained - check your tank connections.", drainedAmount)
-                end
-                return "Fuel leak warning - but the tank was already low."
-            end
-            return "Fuel leak detected, but no vehicle is running."
-        end,
-        ambientMsgs = {
-            "You can smell diesel. Something's dripping under the machine.",
-            "The fuel gauge is dropping faster than it should.",
         },
     },
 
@@ -291,53 +191,9 @@ vehicleEvents.eventList = {
     },
 
     {
-        name = "vehicle_free_upgrade",
-        minI = 1,
-        func = function(intensity)
-            local vehicle = vehicleEvents.getVehicle()
-            if vehicle and vehicle.getColor and vehicle.setColor then
-                if not vehicle.originalColor then
-                    vehicle.originalColor = { vehicle:getColor() }
-                end
-                local r, g, b = unpack(vehicle.originalColor)
-                vehicle:setColor(r * 1.2, g * 1.1, b * 0.9)
-                if g_RandomWorldEvents then
-                    g_RandomWorldEvents.EVENT_STATE.vehicleUpgrade = { vehicle = vehicle }
-                end
-                return "Showroom shine! Your machine got a fresh golden coat."
-            end
-            return "Free upgrade kit arrived - get in a vehicle!"
-        end,
-        ambientMsgs = {
-            "Heads are turning as you drive past. The paint job looks immaculate.",
-            "Someone asked if it was a new model. Close enough.",
-        },
-    },
-
-    {
-        name = "vehicle_cleaning_bonus",
-        minI = 1,
-        func = function(intensity)
-            local vehicles = vehicleEvents.getAllVehicles()
-            local cleanedCount = 0
-            for _, vehicle in ipairs(vehicles) do
-                if vehicle and vehicle.getDirtAmount then
-                    if (vehicle:getDirtAmount() or 0) > 0 then
-                        vehicle:setDirtAmount(0)
-                        cleanedCount = cleanedCount + 1
-                    end
-                end
-            end
-            if cleanedCount > 0 then
-                return string.format("Pressure wash crew showed up! %d machine%s spotless.", cleanedCount, cleanedCount > 1 and "s" or "")
-            end
-            return "Cleaning crew arrived - machines were already gleaming."
-        end,
-    },
-
-    {
         name = "vehicle_engine_trouble",
         minI = 2,
+        gate = "arcadePhysics",
         func = function(intensity)
             local vehicle = vehicleEvents.getVehicle()
             if vehicle and RWEVehiclePhysics then
@@ -361,57 +217,6 @@ vehicleEvents.eventList = {
         },
     },
 
-    {
-        name = "vehicle_steering_pull",
-        minI = 2,
-        -- Short event; the pull itself comes in periodic eased tugs, not a
-        -- constant lean (see RWEVehiclePhysics.onPreUpdate).
-        dur = { min = 2, max = 4 },
-        func = function(intensity)
-            local vehicle = vehicleEvents.getVehicle()
-            if vehicle and RWEVehiclePhysics then
-                local side = (math.random() < 0.5) and -1 or 1
-                local pull = side * math.min(0.40, 0.12 + 0.04 * intensity)
-                RWEVehiclePhysics.applyEventMods(vehicle, { steerPull = pull })
-                vehicleEvents.trackPhysics(vehicle)
-                local dir = side < 0 and "left" or "right"
-                return string.format("Loose front axle! The wheel keeps tugging to the %s.", dir)
-            end
-            return "Steering feels off, but no vehicle is running."
-        end,
-        onMid = function(intensity)
-            return "Still tugging every so often - keep a hand on the wheel."
-        end,
-        ambientMsgs = {
-            "Every now and then the wheel jerks to one side.",
-            "That tie rod really needs looking at.",
-        },
-    },
-
-    {
-        name = "vehicle_slippery_roads",
-        minI = 1,
-        func = function(intensity)
-            local vehicle = vehicleEvents.getVehicle()
-            if vehicle and RWEVehiclePhysics then
-                -- Greasy, low-traction conditions: calmer throttle and a
-                -- lower safe speed so the machine is easier to keep straight.
-                local accelScale = math.max(0.4, 1 - (0.10 * intensity))
-                local speedScale = math.max(0.55, 1 - (0.08 * intensity))
-                RWEVehiclePhysics.applyEventMods(vehicle, { accelScale = accelScale, speedScale = speedScale })
-                vehicleEvents.trackPhysics(vehicle)
-                return "Slippery going! Easy on the throttle until the roads dry out."
-            end
-            return "Roads are greasy out there - mind your footing."
-        end,
-        onMid = function(intensity)
-            return "Surfaces are still slick. Take it steady."
-        end,
-        ambientMsgs = {
-            "The tyres are scrabbling for grip on every pull-away.",
-            "A light film of mud on the road has everything sliding.",
-        },
-    },
 }
 
 -- =====================
@@ -438,19 +243,9 @@ local function registerVehicleEvents()
                 if g_RandomWorldEvents then
                     local d = g_RandomWorldEvents.EVENT_STATE
 
-                    -- Restore any vehicle physics modifiers (speed / engine /
-                    -- steering) applied by this event.
+                    -- Restore any vehicle physics modifiers (speed / engine)
+                    -- applied by this event.
                     vehicleEvents.restoreTrackedPhysics()
-
-                    if d.vehicleUpgrade then
-                        local v = d.vehicleUpgrade.vehicle
-                        if v and v.originalColor and v.setColor then
-                            local r, g, b = unpack(v.originalColor)
-                            v:setColor(r, g, b)
-                            v.originalColor = nil
-                        end
-                        d.vehicleUpgrade = nil
-                    end
 
                     d.vehicleAccident = nil
                 end


### PR DESCRIPTION
## Summary
Pre-release candidate for the Realistic Farming suite (Aug 17-24, 2026). Major redesign of the non-price event system, MasterHUD fullscreen claim integration, and playtest fixes.

## Commits
- Merge PR #37: fix(input) skip cab re-register when RWE vehicle actions are live (FAILFIX)
- Merge PR #36: feat RandomWorldEvents redesign, non-price half
- Merge PR #35: feat(hud) declare the fullscreen claim to MasterHUD
- Merge PR #34: fix(hud) the event HUD stands down while the settings panel is open
- Merge PR #33: chore(rwe) leftover MasterHUD bridge
- Merge PR #32: docs one feature, one PR (Tyson's ruling)
- chore: add the Lua 5.1 pre-commit gate