### PR TITLE
fix: hot-reload conformance, suite-edit/vehicle input, docs truth (2026-08-22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ All settings save per-savegame, so each farm can have its own configuration.
 - **45+ unique events** across 4 active categories
 - Configurable **frequency** (1-10), **intensity** (1-5), and **cooldown** (1-240 min)
 - Events trigger automatically on a probability timer during gameplay
-- Manual trigger via **F9** or the `rweTest` console command
+- Manual trigger via the `rweTest` console command
 - Per-category enable/disable toggles (economic, vehicle, field, special)
 - In-game HUD notifications and warnings when events start and end
 - Single active event at a time - a cooldown prevents event spam
@@ -130,8 +130,9 @@ Open the in-game console (`` ` `` key) and type any of these:
 
 | Key | Action |
 |-----|--------|
-| **F9** | Force-trigger a random event |
-| **F3** | Open settings screen *(coming soon)* |
+| `rweTest` (console command) | Force-trigger a random event |
+| *Toggle World Events HUD* action | Show/hide the event HUD (no default key - assign one under Options > Controls > Mods) |
+| *Toggle World Events Settings* action | Open the settings screen (no default key - assign one under Options > Controls > Mods) |
 
 ---
 
@@ -169,7 +170,6 @@ Open the in-game console (`` ` `` key) and type any of these:
 - Complete wildlife/animal event category
 - Complete weather event category
 - Multiplayer-safe money synchronization
-- Full F3 settings screen keybind
 - Event history log viewable in-game
 - Weighted event selection (rare vs. common events)
 

--- a/RandomWorldEvents.lua
+++ b/RandomWorldEvents.lua
@@ -11,8 +11,15 @@
 -- Original author: TisonK
 -- =========================================================
 
-local modDirectory = g_currentModDirectory
-local modName = g_currentModName
+-- Hot-reload latch (FuelCosts reference): g_currentModDirectory and
+-- g_currentModName are nil on a live re-source, so they are latched into
+-- module globals on first load, with a g_modsDirectory loose-folder fallback.
+RandomWorldEventsModDirectory = RandomWorldEventsModDirectory
+    or g_currentModDirectory
+    or (g_modsDirectory ~= nil and (g_modsDirectory .. "FS25_RandomWorldEvents/") or nil)
+RandomWorldEventsModName = RandomWorldEventsModName or g_currentModName or "FS25_RandomWorldEvents"
+local modDirectory = RandomWorldEventsModDirectory
+local modName = RandomWorldEventsModName
 
 -- Resolve mod version once at load time so it's available everywhere.
 local modVersion = "?"
@@ -851,7 +858,7 @@ function RandomWorldEvents:consoleCommandHelp()
     print("rweStatus    - Show current status")
     print("rweTest      - Force-trigger random event")
     print("rweEnd       - End current event")
-    print("rweSettings  - Open settings screen (also F3)")
+    print("rweSettings  - Open settings screen (or the RWE_TOGGLE_SETTINGS key you assigned in Controls)")
     print("rweDebug on|off - Toggle debug mode")
     print("rweList [category] - List registered events")
     print("================================")

--- a/ReleaseGate.lua
+++ b/ReleaseGate.lua
@@ -14,7 +14,7 @@
 -- system for a stable release is a deliberate act, never a default.
 -- =========================================================
 
-ReleaseGate = {}
+ReleaseGate = ReleaseGate or {}
 
 -- The certified experimental (LOCKED) set. Each entry: [systemId] = { name, status }.
 -- `status` is a SHORT player-facing note on what is not working or implemented yet.

--- a/api/RWEBaseAPI.lua
+++ b/api/RWEBaseAPI.lua
@@ -22,7 +22,7 @@
 -- =========================================================
 
 ---@class RWEBaseAPI
-RWEBaseAPI = {}
+RWEBaseAPI = RWEBaseAPI or {}
 
 --- Inject all shared methods into a category API table.
 ---@param target table  The category API table (e.g. RWEEconomicAPI)

--- a/gui/RWEEventHUD.lua
+++ b/gui/RWEEventHUD.lua
@@ -5,7 +5,7 @@
 -- time-remaining progress bar, and flash notifications.
 -- RMB on panel → drag/resize (IncomeMod/NPCFavor pattern).
 -- Position/scale persisted to savegame XML.
--- Toggle: RWE_TOGGLE_HUD action (default F3).
+-- Toggle: RWE_TOGGLE_HUD action (no default key, player-assigned in Controls).
 -- =========================================================
 -- Author: TisonK
 -- =========================================================
@@ -51,7 +51,7 @@ function RWEEventHUD.new(rweInstance)
 
     self.rwe = rweInstance
 
-    -- Visibility (F3 toggle — not persisted)
+    -- Visibility (RWE_TOGGLE_HUD toggle — not persisted)
     self.visible = true
 
     -- Panel anchor: top-left text origin
@@ -61,8 +61,8 @@ function RWEEventHUD.new(rweInstance)
     -- Saved hudLayout XML still wins on load.
     -- Wizard 2026-08-21: factory home is the suite layout Wizard arranged
     -- in-game (bottom-center lane). A saved hudLayout XML still wins on load.
-    self.posX       = 0.421354
-    self.posY       = 0.978148
+    self.posX       = 0.420312
+    self.posY       = 0.980000
     self.panelWidth = 0.20
 
     -- Layout constants at scale 1.0
@@ -74,7 +74,7 @@ function RWEEventHUD.new(rweInstance)
     self.BAR_H       = 0.005556 -- 6 px at 1080p, base fill-level height
 
     -- Scale & edit state (IncomeMod pattern)
-    self.scale            = 1.235293   -- factory suite layout (Wizard 2026-08-21)
+    self.scale            = 1.065217   -- factory suite layout (Wizard 2026-08-22)
     self.editMode         = false
     self.dragging         = false
     self.resizing         = false
@@ -87,7 +87,7 @@ function RWEEventHUD.new(rweInstance)
     self.animTimer        = 0
 
     -- Width state (edge-drag, NPCFavor/Workplace pattern)
-    self.widthMult          = 0.700000   -- factory suite layout (Wizard 2026-08-21)
+    self.widthMult          = 0.857812   -- factory suite layout (Wizard 2026-08-22)
     self.edgeDragging       = nil   -- nil | "left" | "right"
     self.edgeDragStartX     = 0
     self.edgeDragStartWidth = 1.0
@@ -155,7 +155,7 @@ function RWEEventHUD:delete()
 end
 
 -- =========================================================
--- Visibility toggle (F3)
+-- Visibility toggle (RWE_TOGGLE_HUD)
 -- =========================================================
 
 function RWEEventHUD:toggleVisibility()

--- a/gui/RWESettingsIntegration.lua
+++ b/gui/RWESettingsIntegration.lua
@@ -16,7 +16,7 @@
 -- Author: TisonK
 -- =========================================================
 
-RWESettingsIntegration = {}
+RWESettingsIntegration = RWESettingsIntegration or {}
 RWESettingsIntegration_mt = Class(RWESettingsIntegration)
 
 -- Dropdown option tables
@@ -128,7 +128,7 @@ function RWESettingsIntegration:addSettingsElements(frame)
     frame.rwe_showHUD = RWESettingsIntegration:addBinaryOption(
         frame, "onRWEShowHUDChanged",
         g_i18n:getText("rwe_show_hud_short") or "Show HUD Panel",
-        g_i18n:getText("rwe_show_hud_long")  or "Show the World Events HUD overlay (F3 to toggle in-game)"
+        g_i18n:getText("rwe_show_hud_long")  or "Show the World Events HUD overlay (toggle key assignable in Controls)"
     )
 
     frame.rwe_hudScale = RWESettingsIntegration:addMultiTextOption(

--- a/gui/RWESettingsPanel.lua
+++ b/gui/RWESettingsPanel.lua
@@ -9,7 +9,7 @@
 -- =========================================================
 
 ---@class RWESettingsPanel
-RWESettingsPanel = {}
+RWESettingsPanel = RWESettingsPanel or {}
 local RWESettingsPanel_mt = Class(RWESettingsPanel)
 
 -- =========================================================

--- a/integrations/RWEMasterHUDBridge.lua
+++ b/integrations/RWEMasterHUDBridge.lua
@@ -26,7 +26,7 @@
 -- The cross-mod handle is g_currentMission.masterHUD (published in Mission00.load).
 -- =========================================================
 
-RWEMasterHUDBridge = {}
+RWEMasterHUDBridge = RWEMasterHUDBridge or {}
 
 RWEMasterHUDBridge.HUD_ID = "RandomWorldEvents_HUD"
 RWEMasterHUDBridge.active = false   -- MasterHUD present and we registered

--- a/integrations/RWESettingsHubBridge.lua
+++ b/integrations/RWESettingsHubBridge.lua
@@ -29,7 +29,7 @@
 -- mod environment.
 -- =========================================================
 
-RWESettingsHubBridge = {}
+RWESettingsHubBridge = RWESettingsHubBridge or {}
 
 -- id -> descriptor. section/key locate the live value in the nested settings
 -- tables (section "top" = the manager itself for hudScale). type maps onto the

--- a/integrations/RWEStateLedgerBridge.lua
+++ b/integrations/RWEStateLedgerBridge.lua
@@ -36,7 +36,7 @@
 -- The cross-mod handle is g_currentMission.stateLedger (published in Mission00.load).
 -- =========================================================
 
-RWEStateLedgerBridge = {}
+RWEStateLedgerBridge = RWEStateLedgerBridge or {}
 
 -- LOCKED persistence key. Never renamed after first persist (a later rename
 -- orphans saved event state). Matches the <Mod>_<Thing> convention.

--- a/utils/OptionScalingResolver.lua
+++ b/utils/OptionScalingResolver.lua
@@ -29,7 +29,7 @@
 -- neutral, so a system can be turned fully off and the game still plays.
 -- =========================================================
 
-OptionScalingResolver = {}
+OptionScalingResolver = OptionScalingResolver or {}
 
 -- Bump only on a wire-contract change (a renamed dial, a new key shape). A
 -- consumer can compare this against its vendored copy to detect drift.

--- a/utils/RWEUIHelper.lua
+++ b/utils/RWEUIHelper.lua
@@ -4,7 +4,7 @@
 -- Based on the cloning pattern from Worker Costs / Soil Fertilizer
 -- =========================================================
 
-RWEUIHelper = {}
+RWEUIHelper = RWEUIHelper or {}
 
 local function getTextSafe(key)
     local text = g_i18n:getText(key)

--- a/utils/VehiclePhysics.lua
+++ b/utils/VehiclePhysics.lua
@@ -28,9 +28,9 @@
 RWEVehiclePhysics = RWEVehiclePhysics or {}
 
 RWEVehiclePhysics.SPEC_NAME = "rweVehiclePhysics"
--- Captured at source time, while g_currentModName is still this mod.
-RWEVehiclePhysics.MOD_NAME = RWEVehiclePhysics.MOD_NAME or (g_currentModName or "FS25_RandomWorldEvents")
-RWEVehiclePhysics.MOD_DIR  = RWEVehiclePhysics.MOD_DIR or g_currentModDirectory
+-- Captured at source time, while (RandomWorldEventsModName or g_currentModName) is still this mod.
+RWEVehiclePhysics.MOD_NAME = RWEVehiclePhysics.MOD_NAME or ((RandomWorldEventsModName or g_currentModName) or "FS25_RandomWorldEvents")
+RWEVehiclePhysics.MOD_DIR  = RWEVehiclePhysics.MOD_DIR or (RandomWorldEventsModDirectory or g_currentModDirectory)
 RWEVehiclePhysics._validateHookInstalled = false
 RWEVehiclePhysics._didRegisterGlobally   = false
 


### PR DESCRIPTION
fix: hot-reload conformance, suite-edit/vehicle input, docs truth (2026-08-22)

- entry/module latch: g_currentModDirectory/Name latched into module globals with g_modsDirectory fallback so live re-source cannot nil-crash
- hot-reload conformance: class tables declared X = X or {} so Ctrl+R reloads update live instances; raw g_currentModDirectory readers fall back to the latch
- docs: key bindings / HUD behaviour brought in line with the actual modDesc bindings (no phantom default keys)

Built zips are not part of this change. UTF-8 without BOM on all touched files.