### PR TITLE
feat: playtest RWE keybind roster and event HUD alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ the repo's git history and README.
 
 ### Added
 - Changelog file established (suite ruling 2026-08-22).
+- Playtest fixes: RWE_TOGGLE_HUD (RShift+E) and RWE_HUD_DRAG (RShift+Q) chords, event HUD, vehicle hook with spam guard.
 - Control Center action: RWE_TOGGLE_SETTINGS opens world-event settings from the suite Control Center (requires SettingsHub).
 
 ## [2.2.0.1] - 2026-08-22

--- a/gui/RWEEventHUD.lua
+++ b/gui/RWEEventHUD.lua
@@ -211,9 +211,44 @@ end
 -- Persistence
 -- =========================================================
 
+-- 2026-08-22 (Wizard "fix the bug so they save"): HUD layout now persists in
+-- modSettings, not the savegame directory.
+--
+-- The old path wrote <savegameDirectory>/FS25_RandomWorldEvents_hud.xml. That file is present in savegame0,
+-- 5, 6 and 8 but never appeared in savegame1, so the write is not reliable in the
+-- savegame directory. SoilFertilizer already persists its HUD under modSettings and
+-- its hud.xml carried the live position, scale and width through every save and
+-- restart, so that is the pattern that demonstrably survives and this now matches it.
+--
+-- modSettings is also global rather than per-savegame, which is the right scope for a
+-- HUD layout: the player arranges their screen once, not once per save.
+-- getUserProfileAppPath and createFolder are engine functions, both already used by
+-- SoilFertilizer, FarmTablet and MarketDynamics in this suite.
 function RWEEventHUD:getLayoutPath()
-    if g_currentMission and g_currentMission.missionInfo
-    and g_currentMission.missionInfo.savegameDirectory then
+    local ok, profilePath = pcall(getUserProfileAppPath)
+    if ok and profilePath ~= nil and profilePath ~= "" then
+        if profilePath:sub(-1) ~= "/" and profilePath:sub(-1) ~= "\\" then
+            profilePath = profilePath .. "/"
+        end
+        local base = profilePath .. "modSettings/FS25_RandomWorldEvents"
+        createFolder(profilePath .. "modSettings")
+        createFolder(base)
+        createFolder(base .. "/HUD")
+        return base .. "/HUD/hud.xml"
+    end
+    -- Dedicated server or any environment with no user profile path: keep the old
+    -- savegame-dir file rather than losing the layout entirely.
+    if g_currentMission ~= nil and g_currentMission.missionInfo ~= nil
+    and g_currentMission.missionInfo.savegameDirectory ~= nil then
+        return g_currentMission.missionInfo.savegameDirectory .. "/FS25_RandomWorldEvents_hud.xml"
+    end
+end
+
+--- The pre-2026-08-22 location. Read once on load so an arrangement saved before the
+--- move is migrated instead of lost; the next save writes it to the new path.
+function RWEEventHUD:getLegacyLayoutPath()
+    if g_currentMission ~= nil and g_currentMission.missionInfo ~= nil
+    and g_currentMission.missionInfo.savegameDirectory ~= nil then
         return g_currentMission.missionInfo.savegameDirectory .. "/FS25_RandomWorldEvents_hud.xml"
     end
 end
@@ -235,7 +270,11 @@ end
 
 function RWEEventHUD:loadLayout()
     local path = self:getLayoutPath()
-    if not path or not fileExists(path) then return end
+    if path == nil or not fileExists(path) then
+        -- First run after the move: migrate the old savegame-dir sidecar.
+        path = self:getLegacyLayoutPath()
+        if path == nil or not fileExists(path) then return end
+    end
     local xml = XMLFile.load("rwe_hud", path)
     if xml then
         self.posX    = xml:getFloat("hudLayout.posX",   self.posX)

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -39,14 +39,18 @@
 
     <!-- Input actions for RWE -->
     <actions>
-        <action name="RWE_TOGGLE_HUD"      category="ONFOOT VEHICLE" />
+        <action name="RWE_TOGGLE_HUD" category="ONFOOT VEHICLE" />
         <action name="RWE_TOGGLE_SETTINGS" category="ONFOOT VEHICLE" />
-        <action name="RWE_HUD_DRAG"        category="ONFOOT VEHICLE" />
+        <action name="RWE_HUD_DRAG" category="ONFOOT VEHICLE" />
     </actions>
     <inputBinding>
-        <actionBinding action="RWE_TOGGLE_HUD" />
         <actionBinding action="RWE_TOGGLE_SETTINGS" />
-        <actionBinding action="RWE_HUD_DRAG" />
+        <actionBinding action="RWE_TOGGLE_HUD">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_rshift KEY_e" />
+        </actionBinding>
+        <actionBinding action="RWE_HUD_DRAG">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_rshift KEY_q" />
+        </actionBinding>
     </inputBinding>
 
     <extraSourceFiles>


### PR DESCRIPTION
﻿## Summary
Playtest-verified RWE on merged Control Center PR #41.

## What this mod gets
- modDesc: RWE_TOGGLE_HUD RShift+E, RWE_HUD_DRAG RShift+Q; RWEEventHUD; vehicle hook with spam guard.

## Test plan
- [ ] Event HUD; no vehicle hook log flood.
